### PR TITLE
Add nullable

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -1,17 +1,17 @@
 use super::OptionalRandBound;
-use proof_of_sql::base::database::{ColumnType, ColumnTypeAssociatedData};
+use proof_of_sql::base::database::{ColumnNullability, ColumnType};
 
 const SINGLE_COLUMN_FILTER_TITLE: &str = "Single Column Filter";
 const SINGLE_COLUMN_FILTER_SQL: &str = "SELECT b FROM table WHERE a = 0";
 const SINGLE_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "b",
-        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::VarChar(ColumnNullability::NotNullable),
         None,
     ),
 ];
@@ -21,17 +21,17 @@ const MULTI_COLUMN_FILTER_SQL: &str =
 const MULTI_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "b",
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "c",
-        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::VarChar(ColumnNullability::NotNullable),
         None,
     ),
 ];
@@ -40,17 +40,17 @@ const ARITHMETIC_SQL: &str = "SELECT a + b as r0, a * b - 2 as r1, c FROM table 
 const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "b",
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "c",
-        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::VarChar(ColumnNullability::NotNullable),
         None,
     ),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -1,15 +1,19 @@
 use super::OptionalRandBound;
-use proof_of_sql::base::database::ColumnType;
+use proof_of_sql::base::database::{ColumnType, ColumnTypeAssociatedData};
 
 const SINGLE_COLUMN_FILTER_TITLE: &str = "Single Column Filter";
 const SINGLE_COLUMN_FILTER_SQL: &str = "SELECT b FROM table WHERE a = 0";
 const SINGLE_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt,
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         Some(|size| (size / 10).max(10) as i64),
     ),
-    ("b", ColumnType::VarChar, None),
+    (
+        "b",
+        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        None,
+    ),
 ];
 const MULTI_COLUMN_FILTER_TITLE: &str = "Multi Column Filter";
 const MULTI_COLUMN_FILTER_SQL: &str =
@@ -17,30 +21,38 @@ const MULTI_COLUMN_FILTER_SQL: &str =
 const MULTI_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt,
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "b",
-        ColumnType::BigInt,
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         Some(|size| (size / 10).max(10) as i64),
     ),
-    ("c", ColumnType::VarChar, None),
+    (
+        "c",
+        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        None,
+    ),
 ];
 const ARITHMETIC_TITLE: &str = "Arithmetic";
 const ARITHMETIC_SQL: &str = "SELECT a + b as r0, a * b - 2 as r1, c FROM table WHERE a >= b";
 const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
-        ColumnType::BigInt,
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         Some(|size| (size / 10).max(10) as i64),
     ),
     (
         "b",
-        ColumnType::BigInt,
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         Some(|size| (size / 10).max(10) as i64),
     ),
-    ("c", ColumnType::VarChar, None),
+    (
+        "c",
+        ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+        None,
+    ),
 ];
 
 #[allow(clippy::type_complexity)]

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -307,11 +307,11 @@ impl ColumnBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
     use alloc::{string::String, vec};
     use itertools::Itertools;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_bounds_by_method() {
@@ -499,7 +499,8 @@ mod tests {
     #[test]
     fn we_can_construct_column_bounds_from_column() {
         let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
-        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(meta,
+        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Lorem", "ipsum", "dolor", "sit", "amet"]
                 .map(String::from)
                 .to_vec(),
@@ -508,7 +509,8 @@ mod tests {
         let varchar_column_bounds = ColumnBounds::from_column(&committable_varchar_column);
         assert_eq!(varchar_column_bounds, ColumnBounds::NoOrder);
 
-        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
+        let tinyint_column =
+            OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_tinyint_column = CommittableColumn::from(&tinyint_column);
         let tinyint_column_bounds = ColumnBounds::from_column(&committable_tinyint_column);
         assert_eq!(
@@ -516,7 +518,8 @@ mod tests {
             ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
+        let smallint_column =
+            OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_column_bounds = ColumnBounds::from_column(&committable_smallint_column);
         assert_eq!(

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -308,7 +308,7 @@ impl ColumnBounds {
 mod tests {
     use super::*;
     use crate::base::{
-        database::{ColumnTypeAssociatedData, OwnedColumn},
+        database::{ColumnNullability, OwnedColumn},
         math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_column_bounds_from_column() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
             meta,
             ["Lorem", "ipsum", "dolor", "sit", "amet"]

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -307,8 +307,11 @@ impl ColumnBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
-    use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
+    use crate::base::{
+        database::{ColumnTypeAssociatedData, OwnedColumn},
+        math::decimal::Precision,
+        scalar::Curve25519Scalar,
+    };
     use alloc::{string::String, vec};
     use itertools::Itertools;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -311,6 +311,7 @@ mod tests {
     use alloc::{string::String, vec};
     use itertools::Itertools;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_bounds_by_method() {
@@ -497,7 +498,8 @@ mod tests {
 
     #[test]
     fn we_can_construct_column_bounds_from_column() {
-        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(meta,
             ["Lorem", "ipsum", "dolor", "sit", "amet"]
                 .map(String::from)
                 .to_vec(),
@@ -506,7 +508,7 @@ mod tests {
         let varchar_column_bounds = ColumnBounds::from_column(&committable_varchar_column);
         assert_eq!(varchar_column_bounds, ColumnBounds::NoOrder);
 
-        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt([1, 2, 3, 1, 0].to_vec());
+        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_tinyint_column = CommittableColumn::from(&tinyint_column);
         let tinyint_column_bounds = ColumnBounds::from_column(&committable_tinyint_column);
         assert_eq!(
@@ -514,7 +516,7 @@ mod tests {
             ColumnBounds::TinyInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
+        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_column_bounds = ColumnBounds::from_column(&committable_smallint_column);
         assert_eq!(
@@ -522,7 +524,7 @@ mod tests {
             ColumnBounds::SmallInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let int_column = OwnedColumn::<Curve25519Scalar>::Int([1, 2, 3, 1, 0].to_vec());
+        let int_column = OwnedColumn::<Curve25519Scalar>::Int(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_int_column = CommittableColumn::from(&int_column);
         let int_column_bounds = ColumnBounds::from_column(&committable_int_column);
         assert_eq!(
@@ -530,7 +532,7 @@ mod tests {
             ColumnBounds::Int(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt([1, 2, 3, 1, 0].to_vec());
+        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_bigint_column = CommittableColumn::from(&bigint_column);
         let bigint_column_bounds = ColumnBounds::from_column(&committable_bigint_column);
         assert_eq!(
@@ -538,7 +540,7 @@ mod tests {
             ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 0, max: 3 }))
         );
 
-        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128([1, 2, 3, 1, 0].to_vec());
+        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_int128_column = CommittableColumn::from(&int128_column);
         let int128_column_bounds = ColumnBounds::from_column(&committable_int128_column);
         assert_eq!(
@@ -547,6 +549,7 @@ mod tests {
         );
 
         let decimal75_column = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
             Precision::new(1).unwrap(),
             0,
             vec![
@@ -560,6 +563,7 @@ mod tests {
         assert_eq!(decimal75_column_bounds, ColumnBounds::NoOrder);
 
         let timestamp_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+            meta,
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             vec![1_i64, 2, 3, 4],

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -44,17 +44,17 @@ impl ColumnCommitmentMetadata {
         bounds: ColumnBounds,
     ) -> Result<ColumnCommitmentMetadata, InvalidColumnCommitmentMetadata> {
         match (column_type, bounds) {
-            (ColumnType::TinyInt, ColumnBounds::TinyInt(_))
-            | (ColumnType::SmallInt, ColumnBounds::SmallInt(_))
-            | (ColumnType::Int, ColumnBounds::Int(_))
-            | (ColumnType::BigInt, ColumnBounds::BigInt(_))
-            | (ColumnType::Int128, ColumnBounds::Int128(_))
-            | (ColumnType::TimestampTZ(_, _), ColumnBounds::TimestampTZ(_))
+            (ColumnType::TinyInt(_), ColumnBounds::TinyInt(_))
+            | (ColumnType::SmallInt(_), ColumnBounds::SmallInt(_))
+            | (ColumnType::Int(_), ColumnBounds::Int(_))
+            | (ColumnType::BigInt(_), ColumnBounds::BigInt(_))
+            | (ColumnType::Int128(_), ColumnBounds::Int128(_))
+            | (ColumnType::TimestampTZ(_, _, _), ColumnBounds::TimestampTZ(_))
             | (
-                ColumnType::Boolean
-                | ColumnType::VarChar
-                | ColumnType::Scalar
-                | ColumnType::Decimal75(..),
+                ColumnType::Boolean(_)
+                | ColumnType::VarChar(_)
+                | ColumnType::Scalar(_)
+                | ColumnType::Decimal75(_, ..),
                 ColumnBounds::NoOrder,
             ) => Ok(ColumnCommitmentMetadata {
                 column_type,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -181,9 +181,10 @@ impl ColumnCommitmentMetadata {
 mod tests {
 
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
-        commitment::column_bounds::Bounds, database::OwnedColumn, math::decimal::Precision,
+        commitment::column_bounds::Bounds,
+        database::{ColumnTypeAssociatedData, OwnedColumn},
+        math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
     use alloc::string::String;

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -181,13 +181,13 @@ impl ColumnCommitmentMetadata {
 mod tests {
 
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         commitment::column_bounds::Bounds, database::OwnedColumn, math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
     use alloc::string::String;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_metadata() {
@@ -217,8 +217,11 @@ mod tests {
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::Int(meta), ColumnBounds::Int(Bounds::Empty))
-                .unwrap(),
+            ColumnCommitmentMetadata::try_new(
+                ColumnType::Int(meta),
+                ColumnBounds::Int(Bounds::Empty)
+            )
+            .unwrap(),
             ColumnCommitmentMetadata {
                 column_type: ColumnType::Int(meta),
                 bounds: ColumnBounds::Int(Bounds::Empty)
@@ -238,7 +241,8 @@ mod tests {
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::Boolean(meta), ColumnBounds::NoOrder,).unwrap(),
+            ColumnCommitmentMetadata::try_new(ColumnType::Boolean(meta), ColumnBounds::NoOrder,)
+                .unwrap(),
             ColumnCommitmentMetadata {
                 column_type: ColumnType::Boolean(meta),
                 bounds: ColumnBounds::NoOrder,
@@ -264,7 +268,11 @@ mod tests {
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+                column_type: ColumnType::TimestampTZ(
+                    meta,
+                    PoSQLTimeUnit::Second,
+                    PoSQLTimeZone::Utc
+                ),
                 bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
             }
         );
@@ -282,7 +290,8 @@ mod tests {
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::VarChar(meta), ColumnBounds::NoOrder).unwrap(),
+            ColumnCommitmentMetadata::try_new(ColumnType::VarChar(meta), ColumnBounds::NoOrder)
+                .unwrap(),
             ColumnCommitmentMetadata {
                 column_type: ColumnType::VarChar(meta),
                 bounds: ColumnBounds::NoOrder
@@ -381,8 +390,10 @@ mod tests {
     #[test]
     fn we_can_construct_metadata_from_column() {
         let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
-        let boolean_column =
-            OwnedColumn::<Curve25519Scalar>::Boolean(meta, [true, false, true, false, true].to_vec());
+        let boolean_column = OwnedColumn::<Curve25519Scalar>::Boolean(
+            meta,
+            [true, false, true, false, true].to_vec(),
+        );
         let committable_boolean_column = CommittableColumn::from(&boolean_column);
         let boolean_metadata = ColumnCommitmentMetadata::from_column(&committable_boolean_column);
         assert_eq!(boolean_metadata.column_type(), &ColumnType::Boolean(meta));
@@ -456,7 +467,8 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::Int(Bounds::Sharp(_))");
         }
 
-        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
+        let tinyint_column =
+            OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_tinyint_column = CommittableColumn::from(&tinyint_column);
         let tinyint_metadata = ColumnCommitmentMetadata::from_column(&committable_tinyint_column);
         assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt(meta));
@@ -467,7 +479,8 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::TinyInt(Bounds::Sharp(_))");
         }
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
+        let smallint_column =
+            OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_metadata = ColumnCommitmentMetadata::from_column(&committable_smallint_column);
         assert_eq!(smallint_metadata.column_type(), &ColumnType::SmallInt(meta));
@@ -707,7 +720,10 @@ mod tests {
         let b_difference_a = tinyint_metadata_b
             .try_difference(tinyint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            b_difference_a.column_type,
+            ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
         if let ColumnBounds::TinyInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -744,7 +760,10 @@ mod tests {
         let b_difference_a = smallint_metadata_b
             .try_difference(smallint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            b_difference_a.column_type,
+            ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
         if let ColumnBounds::SmallInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -779,7 +798,10 @@ mod tests {
         let int_metadata_b = ColumnCommitmentMetadata::from_column(&int_column_b);
 
         let b_difference_a = int_metadata_b.try_difference(int_metadata_a).unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            b_difference_a.column_type,
+            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
         if let ColumnBounds::Int(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -976,7 +998,11 @@ mod tests {
         };
 
         let timestamp_tz_metadata_b = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
+            column_type: ColumnType::TimestampTZ(
+                meta,
+                PoSQLTimeUnit::Millisecond,
+                PoSQLTimeZone::Utc,
+            ),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -72,23 +72,23 @@ impl ColumnCommitmentMetadata {
     #[must_use]
     pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
         let bounds = match column_type {
-            ColumnType::SmallInt => ColumnBounds::SmallInt(super::Bounds::Bounded(
+            ColumnType::SmallInt(_) => ColumnBounds::SmallInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i16::MIN, i16::MAX)
                     .expect("i16::MIN and i16::MAX are valid bounds for SmallInt"),
             )),
-            ColumnType::Int => ColumnBounds::Int(super::Bounds::Bounded(
+            ColumnType::Int(_) => ColumnBounds::Int(super::Bounds::Bounded(
                 BoundsInner::try_new(i32::MIN, i32::MAX)
                     .expect("i32::MIN and i32::MAX are valid bounds for Int"),
             )),
-            ColumnType::BigInt => ColumnBounds::BigInt(super::Bounds::Bounded(
+            ColumnType::BigInt(_) => ColumnBounds::BigInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i64::MIN, i64::MAX)
                     .expect("i64::MIN and i64::MAX are valid bounds for BigInt"),
             )),
-            ColumnType::TimestampTZ(_, _) => ColumnBounds::TimestampTZ(super::Bounds::Bounded(
+            ColumnType::TimestampTZ(_, _, _) => ColumnBounds::TimestampTZ(super::Bounds::Bounded(
                 BoundsInner::try_new(i64::MIN, i64::MAX)
                     .expect("i64::MIN and i64::MAX are valid bounds for TimeStamp"),
             )),
-            ColumnType::Int128 => ColumnBounds::Int128(super::Bounds::Bounded(
+            ColumnType::Int128(_) => ColumnBounds::Int128(super::Bounds::Bounded(
                 BoundsInner::try_new(i128::MIN, i128::MAX)
                     .expect("i128::MIN and i128::MAX are valid bounds for Int128"),
             )),
@@ -187,102 +187,104 @@ mod tests {
     };
     use alloc::string::String;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_metadata() {
+        let meta = ColumnTypeAssociatedData::default();
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::TinyInt,
+                ColumnType::TinyInt(meta),
                 ColumnBounds::TinyInt(Bounds::Empty)
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::TinyInt,
+                column_type: ColumnType::TinyInt(meta),
                 bounds: ColumnBounds::TinyInt(Bounds::Empty)
             }
         );
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::SmallInt,
+                ColumnType::SmallInt(meta),
                 ColumnBounds::SmallInt(Bounds::Empty)
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::SmallInt,
+                column_type: ColumnType::SmallInt(meta),
                 bounds: ColumnBounds::SmallInt(Bounds::Empty)
             }
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::Int, ColumnBounds::Int(Bounds::Empty))
+            ColumnCommitmentMetadata::try_new(ColumnType::Int(meta), ColumnBounds::Int(Bounds::Empty))
                 .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::Int,
+                column_type: ColumnType::Int(meta),
                 bounds: ColumnBounds::Int(Bounds::Empty)
             }
         );
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::BigInt,
+                ColumnType::BigInt(meta),
                 ColumnBounds::BigInt(Bounds::Empty)
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::BigInt,
+                column_type: ColumnType::BigInt(meta),
                 bounds: ColumnBounds::BigInt(Bounds::Empty)
             }
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::Boolean, ColumnBounds::NoOrder,).unwrap(),
+            ColumnCommitmentMetadata::try_new(ColumnType::Boolean(meta), ColumnBounds::NoOrder,).unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::Boolean,
+                column_type: ColumnType::Boolean(meta),
                 bounds: ColumnBounds::NoOrder,
             }
         );
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Decimal75(Precision::new(10).unwrap(), 0),
+                ColumnType::Decimal75(meta, Precision::new(10).unwrap(), 0),
                 ColumnBounds::NoOrder,
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::Decimal75(Precision::new(10).unwrap(), 0),
+                column_type: ColumnType::Decimal75(meta, Precision::new(10).unwrap(), 0),
                 bounds: ColumnBounds::NoOrder,
             }
         );
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+                ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
                 ColumnBounds::TimestampTZ(Bounds::Empty),
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+                column_type: ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
                 bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
             }
         );
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Int128,
+                ColumnType::Int128(meta),
                 ColumnBounds::Int128(Bounds::sharp(-5, 10).unwrap())
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::Int128,
+                column_type: ColumnType::Int128(meta),
                 bounds: ColumnBounds::Int128(Bounds::sharp(-5, 10).unwrap())
             }
         );
 
         assert_eq!(
-            ColumnCommitmentMetadata::try_new(ColumnType::VarChar, ColumnBounds::NoOrder).unwrap(),
+            ColumnCommitmentMetadata::try_new(ColumnType::VarChar(meta), ColumnBounds::NoOrder).unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::VarChar,
+                column_type: ColumnType::VarChar(meta),
                 bounds: ColumnBounds::NoOrder
             }
         );
@@ -290,16 +292,17 @@ mod tests {
 
     #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
+        let meta = ColumnTypeAssociatedData::default();
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Boolean,
+                ColumnType::Boolean(meta),
                 ColumnBounds::BigInt(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Boolean,
+                ColumnType::Boolean(meta),
                 ColumnBounds::Int128(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
@@ -307,14 +310,14 @@ mod tests {
 
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Decimal75(Precision::new(10).unwrap(), 10),
+                ColumnType::Decimal75(meta, Precision::new(10).unwrap(), 10),
                 ColumnBounds::Int128(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Decimal75(Precision::new(10).unwrap(), 10),
+                ColumnType::Decimal75(meta, Precision::new(10).unwrap(), 10),
                 ColumnBounds::BigInt(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
@@ -322,14 +325,14 @@ mod tests {
 
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Scalar,
+                ColumnType::Scalar(meta),
                 ColumnBounds::BigInt(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Scalar,
+                ColumnType::Scalar(meta),
                 ColumnBounds::Int128(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
@@ -337,38 +340,38 @@ mod tests {
 
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::BigInt,
+                ColumnType::BigInt(meta),
                 ColumnBounds::Int128(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
-            ColumnCommitmentMetadata::try_new(ColumnType::BigInt, ColumnBounds::NoOrder),
+            ColumnCommitmentMetadata::try_new(ColumnType::BigInt(meta), ColumnBounds::NoOrder),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
 
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::Int128,
+                ColumnType::Int128(meta),
                 ColumnBounds::BigInt(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
-            ColumnCommitmentMetadata::try_new(ColumnType::Int128, ColumnBounds::NoOrder),
+            ColumnCommitmentMetadata::try_new(ColumnType::Int128(meta), ColumnBounds::NoOrder),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
 
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::VarChar,
+                ColumnType::VarChar(meta),
                 ColumnBounds::BigInt(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
         ));
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::VarChar,
+                ColumnType::VarChar(meta),
                 ColumnBounds::Int128(Bounds::Empty)
             ),
             Err(InvalidColumnCommitmentMetadata::TypeBoundsMismatch { .. })
@@ -377,14 +380,16 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata_from_column() {
+        let meta = ColumnTypeAssociatedData::default();
         let boolean_column =
-            OwnedColumn::<Curve25519Scalar>::Boolean([true, false, true, false, true].to_vec());
+            OwnedColumn::<Curve25519Scalar>::Boolean(meta, [true, false, true, false, true].to_vec());
         let committable_boolean_column = CommittableColumn::from(&boolean_column);
         let boolean_metadata = ColumnCommitmentMetadata::from_column(&committable_boolean_column);
-        assert_eq!(boolean_metadata.column_type(), &ColumnType::Boolean);
+        assert_eq!(boolean_metadata.column_type(), &ColumnType::Boolean(meta));
         assert_eq!(boolean_metadata.bounds(), &ColumnBounds::NoOrder);
 
         let decimal_column = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
             Precision::new(10).unwrap(),
             0,
             [1, 2, 3, 4, 5].map(Curve25519Scalar::from).to_vec(),
@@ -393,12 +398,13 @@ mod tests {
         let decimal_metadata = ColumnCommitmentMetadata::from_column(&committable_decimal_column);
         assert_eq!(
             decimal_metadata.column_type(),
-            &ColumnType::Decimal75(Precision::new(10).unwrap(), 0)
+            &ColumnType::Decimal75(meta, Precision::new(10).unwrap(), 0)
         );
         assert_eq!(decimal_metadata.bounds(), &ColumnBounds::NoOrder);
 
         let timestamp_column: OwnedColumn<Curve25519Scalar> =
             OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+                meta,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 [1i64, 2, 3, 4, 5].to_vec(),
@@ -408,7 +414,7 @@ mod tests {
             ColumnCommitmentMetadata::from_column(&committable_timestamp_column);
         assert_eq!(
             timestamp_metadata.column_type(),
-            &ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc)
+            &ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc)
         );
         if let ColumnBounds::TimestampTZ(Bounds::Sharp(bounds)) = timestamp_metadata.bounds() {
             assert_eq!(bounds.min(), &1);
@@ -418,19 +424,20 @@ mod tests {
         }
 
         let varchar_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Lorem", "ipsum", "dolor", "sit", "amet"]
                 .map(String::from)
                 .to_vec(),
         );
         let committable_varchar_column = CommittableColumn::from(&varchar_column);
         let varchar_metadata = ColumnCommitmentMetadata::from_column(&committable_varchar_column);
-        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar);
+        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar(meta));
         assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
 
-        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt([1, 2, 3, 1, 0].to_vec());
+        let bigint_column = OwnedColumn::<Curve25519Scalar>::BigInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_bigint_column = CommittableColumn::from(&bigint_column);
         let bigint_metadata = ColumnCommitmentMetadata::from_column(&committable_bigint_column);
-        assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt);
+        assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt(meta));
         if let ColumnBounds::BigInt(Bounds::Sharp(bounds)) = bigint_metadata.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -438,10 +445,10 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::BigInt(Bounds::Sharp(_))");
         }
 
-        let int_column = OwnedColumn::<Curve25519Scalar>::Int([1, 2, 3, 1, 0].to_vec());
+        let int_column = OwnedColumn::<Curve25519Scalar>::Int(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_int_column = CommittableColumn::from(&int_column);
         let int_metadata = ColumnCommitmentMetadata::from_column(&committable_int_column);
-        assert_eq!(int_metadata.column_type(), &ColumnType::Int);
+        assert_eq!(int_metadata.column_type(), &ColumnType::Int(meta));
         if let ColumnBounds::Int(Bounds::Sharp(bounds)) = int_metadata.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -449,10 +456,10 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::Int(Bounds::Sharp(_))");
         }
 
-        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt([1, 2, 3, 1, 0].to_vec());
+        let tinyint_column = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_tinyint_column = CommittableColumn::from(&tinyint_column);
         let tinyint_metadata = ColumnCommitmentMetadata::from_column(&committable_tinyint_column);
-        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt);
+        assert_eq!(tinyint_metadata.column_type(), &ColumnType::TinyInt(meta));
         if let ColumnBounds::TinyInt(Bounds::Sharp(bounds)) = tinyint_metadata.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -460,10 +467,10 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::TinyInt(Bounds::Sharp(_))");
         }
 
-        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt([1, 2, 3, 1, 0].to_vec());
+        let smallint_column = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, [1, 2, 3, 1, 0].to_vec());
         let committable_smallint_column = CommittableColumn::from(&smallint_column);
         let smallint_metadata = ColumnCommitmentMetadata::from_column(&committable_smallint_column);
-        assert_eq!(smallint_metadata.column_type(), &ColumnType::SmallInt);
+        assert_eq!(smallint_metadata.column_type(), &ColumnType::SmallInt(meta));
         if let ColumnBounds::SmallInt(Bounds::Sharp(bounds)) = smallint_metadata.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -471,28 +478,29 @@ mod tests {
             panic!("Bounds constructed from nonempty BigInt column should be ColumnBounds::SmallInt(Bounds::Sharp(_))");
         }
 
-        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128([].to_vec());
+        let int128_column = OwnedColumn::<Curve25519Scalar>::Int128(meta, [].to_vec());
         let committable_int128_column = CommittableColumn::from(&int128_column);
         let int128_metadata = ColumnCommitmentMetadata::from_column(&committable_int128_column);
-        assert_eq!(int128_metadata.column_type(), &ColumnType::Int128);
+        assert_eq!(int128_metadata.column_type(), &ColumnType::Int128(meta));
         assert_eq!(
             int128_metadata.bounds(),
             &ColumnBounds::Int128(Bounds::Empty)
         );
 
         let scalar_column =
-            OwnedColumn::Scalar([1, 2, 3, 4, 5].map(Curve25519Scalar::from).to_vec());
+            OwnedColumn::Scalar(meta, [1, 2, 3, 4, 5].map(Curve25519Scalar::from).to_vec());
         let committable_scalar_column = CommittableColumn::from(&scalar_column);
         let scalar_metadata = ColumnCommitmentMetadata::from_column(&committable_scalar_column);
-        assert_eq!(scalar_metadata.column_type(), &ColumnType::Scalar);
+        assert_eq!(scalar_metadata.column_type(), &ColumnType::Scalar(meta));
         assert_eq!(scalar_metadata.bounds(), &ColumnBounds::NoOrder);
     }
 
     #[test]
     fn we_can_union_matching_metadata() {
+        let meta = ColumnTypeAssociatedData::default();
         // NoOrder cases
         let boolean_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Boolean,
+            column_type: ColumnType::Boolean(meta),
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
@@ -501,7 +509,7 @@ mod tests {
         );
 
         let decimal_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Decimal75(Precision::new(12).unwrap(), 0),
+            column_type: ColumnType::Decimal75(meta, Precision::new(12).unwrap(), 0),
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
@@ -510,7 +518,7 @@ mod tests {
         );
 
         let varchar_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::VarChar,
+            column_type: ColumnType::VarChar(meta),
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
@@ -519,7 +527,7 @@ mod tests {
         );
 
         let scalar_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Scalar,
+            column_type: ColumnType::Scalar(meta),
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
@@ -624,7 +632,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::TimestampTZ(timeunit, timezone)
+            ColumnType::TimestampTZ(ColumnTypeAssociatedData::default(), timeunit, timezone)
         );
         if let ColumnBounds::TimestampTZ(Bounds::Bounded(bounds)) = b_difference_a.bounds {
             assert_eq!(bounds.min(), &1_625_065_000);
@@ -653,6 +661,7 @@ mod tests {
 
     #[test]
     fn we_can_difference_bigint_matching_metadata() {
+        let meta = ColumnTypeAssociatedData::default();
         // Ordered case
         let ints = [1, 2, 3, 1, 0];
         let bigint_column_a = CommittableColumn::BigInt(&ints[..2]);
@@ -661,7 +670,7 @@ mod tests {
         let bigint_metadata_b = ColumnCommitmentMetadata::from_column(&bigint_column_b);
 
         let b_difference_a = bigint_metadata_b.try_difference(bigint_metadata_a).unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::BigInt);
+        assert_eq!(b_difference_a.column_type, ColumnType::BigInt(meta));
         if let ColumnBounds::BigInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -698,7 +707,7 @@ mod tests {
         let b_difference_a = tinyint_metadata_b
             .try_difference(tinyint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::TinyInt);
+        assert_eq!(b_difference_a.column_type, ColumnType::TinyInt(ColumnTypeAssociatedData::default()));
         if let ColumnBounds::TinyInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -735,7 +744,7 @@ mod tests {
         let b_difference_a = smallint_metadata_b
             .try_difference(smallint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::SmallInt);
+        assert_eq!(b_difference_a.column_type, ColumnType::SmallInt(ColumnTypeAssociatedData::default()));
         if let ColumnBounds::SmallInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -770,7 +779,7 @@ mod tests {
         let int_metadata_b = ColumnCommitmentMetadata::from_column(&int_column_b);
 
         let b_difference_a = int_metadata_b.try_difference(int_metadata_a).unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::Int);
+        assert_eq!(b_difference_a.column_type, ColumnType::Int(ColumnTypeAssociatedData::default()));
         if let ColumnBounds::Int(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -793,40 +802,41 @@ mod tests {
 
     #[test]
     fn we_cannot_perform_arithmetic_on_mismatched_metadata() {
+        let meta = ColumnTypeAssociatedData::default();
         let boolean_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Boolean,
+            column_type: ColumnType::Boolean(meta),
             bounds: ColumnBounds::NoOrder,
         };
         let varchar_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::VarChar,
+            column_type: ColumnType::VarChar(meta),
             bounds: ColumnBounds::NoOrder,
         };
         let scalar_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Scalar,
+            column_type: ColumnType::Scalar(meta),
             bounds: ColumnBounds::NoOrder,
         };
         let tinyint_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::TinyInt,
+            column_type: ColumnType::TinyInt(meta),
             bounds: ColumnBounds::TinyInt(Bounds::Empty),
         };
         let smallint_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::SmallInt,
+            column_type: ColumnType::SmallInt(meta),
             bounds: ColumnBounds::SmallInt(Bounds::Empty),
         };
         let int_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Int,
+            column_type: ColumnType::Int(meta),
             bounds: ColumnBounds::Int(Bounds::Empty),
         };
         let bigint_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::BigInt,
+            column_type: ColumnType::BigInt(meta),
             bounds: ColumnBounds::BigInt(Bounds::Empty),
         };
         let int128_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Int128,
+            column_type: ColumnType::Int128(meta),
             bounds: ColumnBounds::Int128(Bounds::Empty),
         };
         let decimal75_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Decimal75(Precision::new(4).unwrap(), 8),
+            column_type: ColumnType::Decimal75(meta, Precision::new(4).unwrap(), 8),
             bounds: ColumnBounds::Int128(Bounds::Empty),
         };
 
@@ -942,7 +952,7 @@ mod tests {
         assert!(scalar_metadata.try_difference(boolean_metadata).is_err());
 
         let different_decimal75_metadata = ColumnCommitmentMetadata {
-            column_type: ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+            column_type: ColumnType::Decimal75(meta, Precision::new(75).unwrap(), 0),
             bounds: ColumnBounds::Int128(Bounds::Empty),
         };
 
@@ -961,12 +971,12 @@ mod tests {
             .is_err());
 
         let timestamp_tz_metadata_a = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+            column_type: ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 
         let timestamp_tz_metadata_b = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
+            column_type: ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -183,7 +183,7 @@ mod tests {
     use super::*;
     use crate::base::{
         commitment::column_bounds::Bounds,
-        database::{ColumnTypeAssociatedData, OwnedColumn},
+        database::{ColumnNullability, OwnedColumn},
         math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::TinyInt(meta),
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::Boolean(meta),
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata_from_column() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let boolean_column = OwnedColumn::<Curve25519Scalar>::Boolean(
             meta,
             [true, false, true, false, true].to_vec(),
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn we_can_union_matching_metadata() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // NoOrder cases
         let boolean_metadata = ColumnCommitmentMetadata {
             column_type: ColumnType::Boolean(meta),
@@ -646,7 +646,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, timeunit, timezone)
+            ColumnType::TimestampTZ(ColumnNullability::NotNullable, timeunit, timezone)
         );
         if let ColumnBounds::TimestampTZ(Bounds::Bounded(bounds)) = b_difference_a.bounds {
             assert_eq!(bounds.min(), &1_625_065_000);
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn we_can_difference_bigint_matching_metadata() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Ordered case
         let ints = [1, 2, 3, 1, 0];
         let bigint_column_a = CommittableColumn::BigInt(&ints[..2]);
@@ -723,7 +723,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::TinyInt(ColumnNullability::NotNullable)
         );
         if let ColumnBounds::TinyInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
@@ -763,7 +763,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::SmallInt(ColumnNullability::NotNullable)
         );
         if let ColumnBounds::SmallInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
@@ -801,7 +801,7 @@ mod tests {
         let b_difference_a = int_metadata_b.try_difference(int_metadata_a).unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int(ColumnNullability::NotNullable)
         );
         if let ColumnBounds::Int(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn we_cannot_perform_arithmetic_on_mismatched_metadata() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let boolean_metadata = ColumnCommitmentMetadata {
             column_type: ColumnType::Boolean(meta),
             bounds: ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::TinyInt(meta),
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn we_cannot_construct_metadata_with_type_bounds_mismatch() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         assert!(matches!(
             ColumnCommitmentMetadata::try_new(
                 ColumnType::Boolean(meta),
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata_from_column() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let boolean_column =
             OwnedColumn::<Curve25519Scalar>::Boolean(meta, [true, false, true, false, true].to_vec());
         let committable_boolean_column = CommittableColumn::from(&boolean_column);
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn we_can_union_matching_metadata() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // NoOrder cases
         let boolean_metadata = ColumnCommitmentMetadata {
             column_type: ColumnType::Boolean(meta),
@@ -632,7 +632,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             b_difference_a.column_type,
-            ColumnType::TimestampTZ(ColumnTypeAssociatedData::default(), timeunit, timezone)
+            ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, timeunit, timezone)
         );
         if let ColumnBounds::TimestampTZ(Bounds::Bounded(bounds)) = b_difference_a.bounds {
             assert_eq!(bounds.min(), &1_625_065_000);
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn we_can_difference_bigint_matching_metadata() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Ordered case
         let ints = [1, 2, 3, 1, 0];
         let bigint_column_a = CommittableColumn::BigInt(&ints[..2]);
@@ -707,7 +707,7 @@ mod tests {
         let b_difference_a = tinyint_metadata_b
             .try_difference(tinyint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::TinyInt(ColumnTypeAssociatedData::default()));
+        assert_eq!(b_difference_a.column_type, ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE));
         if let ColumnBounds::TinyInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -744,7 +744,7 @@ mod tests {
         let b_difference_a = smallint_metadata_b
             .try_difference(smallint_metadata_a)
             .unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::SmallInt(ColumnTypeAssociatedData::default()));
+        assert_eq!(b_difference_a.column_type, ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE));
         if let ColumnBounds::SmallInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -779,7 +779,7 @@ mod tests {
         let int_metadata_b = ColumnCommitmentMetadata::from_column(&int_column_b);
 
         let b_difference_a = int_metadata_b.try_difference(int_metadata_a).unwrap();
-        assert_eq!(b_difference_a.column_type, ColumnType::Int(ColumnTypeAssociatedData::default()));
+        assert_eq!(b_difference_a.column_type, ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE));
         if let ColumnBounds::Int(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
             assert_eq!(bounds.max(), &3);
@@ -802,7 +802,7 @@ mod tests {
 
     #[test]
     fn we_cannot_perform_arithmetic_on_mismatched_metadata() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let boolean_metadata = ColumnCommitmentMetadata {
             column_type: ColumnType::Boolean(meta),
             bounds: ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -144,6 +144,7 @@ mod tests {
     };
     use alloc::vec::Vec;
     use itertools::Itertools;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     fn metadata_map_from_owned_table(
         table: OwnedTable<Curve25519Scalar>,
@@ -159,6 +160,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata_map_from_columns() {
+        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // No-columns case
         let empty_metadata_map = ColumnCommitmentMetadataMap::from_columns([]);
         assert_eq!(empty_metadata_map.len(), 0);
@@ -177,7 +179,7 @@ mod tests {
 
         let (index_0, metadata_0) = metadata_map.get_index(0).unwrap();
         assert_eq!(index_0, "bigint_column");
-        assert_eq!(metadata_0.column_type(), &ColumnType::BigInt);
+        assert_eq!(metadata_0.column_type(), &ColumnType::BigInt(col_meta));
         if let ColumnBounds::BigInt(Bounds::Sharp(bounds)) = metadata_0.bounds() {
             assert_eq!(bounds.min(), &-5);
             assert_eq!(bounds.max(), &5);
@@ -187,7 +189,7 @@ mod tests {
 
         let (index_1, metadata_1) = metadata_map.get_index(1).unwrap();
         assert_eq!(index_1, "int128_column");
-        assert_eq!(metadata_1.column_type(), &ColumnType::Int128);
+        assert_eq!(metadata_1.column_type(), &ColumnType::Int128(col_meta));
         if let ColumnBounds::Int128(Bounds::Sharp(bounds)) = metadata_1.bounds() {
             assert_eq!(bounds.min(), &100);
             assert_eq!(bounds.max(), &400);
@@ -197,12 +199,12 @@ mod tests {
 
         let (index_2, metadata_2) = metadata_map.get_index(2).unwrap();
         assert_eq!(index_2, "varchar_column");
-        assert_eq!(metadata_2.column_type(), &ColumnType::VarChar);
+        assert_eq!(metadata_2.column_type(), &ColumnType::VarChar(col_meta));
         assert_eq!(metadata_2.bounds(), &ColumnBounds::NoOrder);
 
         let (index_3, metadata_3) = metadata_map.get_index(3).unwrap();
         assert_eq!(index_3, "scalar_column");
-        assert_eq!(metadata_3.column_type(), &ColumnType::Scalar);
+        assert_eq!(metadata_3.column_type(), &ColumnType::Scalar(col_meta));
         assert_eq!(metadata_3.bounds(), &ColumnBounds::NoOrder);
     }
 
@@ -236,6 +238,7 @@ mod tests {
     }
     #[test]
     fn we_can_difference_matching_metadata_maps() {
+        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let table_a = owned_table([
             bigint("bigint_column", [1, 5]),
             int128("int128_column", [100, 200]),
@@ -259,7 +262,7 @@ mod tests {
         // Check metatadata for ordered columns is mostly the same (now bounded)
         let (index_0, metadata_0) = b_difference_a.get_index(0).unwrap();
         assert_eq!(index_0, "bigint_column");
-        assert_eq!(metadata_0.column_type(), &ColumnType::BigInt);
+        assert_eq!(metadata_0.column_type(), &ColumnType::BigInt(col_meta));
         if let ColumnBounds::BigInt(Bounds::Bounded(bounds)) = metadata_0.bounds() {
             assert_eq!(bounds.min(), &-5);
             assert_eq!(bounds.max(), &10);
@@ -269,7 +272,7 @@ mod tests {
 
         let (index_1, metadata_1) = b_difference_a.get_index(1).unwrap();
         assert_eq!(index_1, "int128_column");
-        assert_eq!(metadata_1.column_type(), &ColumnType::Int128);
+        assert_eq!(metadata_1.column_type(), &ColumnType::Int128(col_meta));
         if let ColumnBounds::Int128(Bounds::Bounded(bounds)) = metadata_1.bounds() {
             assert_eq!(bounds.min(), &100);
             assert_eq!(bounds.max(), &500);

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
-        database::{owned_table_utility::*, ColumnType, ColumnTypeAssociatedData, OwnedTable},
+        database::{owned_table_utility::*, ColumnNullability, ColumnType, OwnedTable},
         scalar::Curve25519Scalar,
     };
     use alloc::vec::Vec;
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_metadata_map_from_columns() {
-        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnNullability::NotNullable;
         // No-columns case
         let empty_metadata_map = ColumnCommitmentMetadataMap::from_columns([]);
         assert_eq!(empty_metadata_map.len(), 0);
@@ -237,7 +237,7 @@ mod tests {
     }
     #[test]
     fn we_can_difference_matching_metadata_maps() {
-        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnNullability::NotNullable;
         let table_a = owned_table([
             bigint("bigint_column", [1, 5]),
             int128("int128_column", [100, 200]),

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -137,10 +137,9 @@ impl ColumnCommitmentMetadataMapExt for ColumnCommitmentMetadataMap {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
-        database::{owned_table_utility::*, ColumnType, OwnedTable},
+        database::{owned_table_utility::*, ColumnType, ColumnTypeAssociatedData, OwnedTable},
         scalar::Curve25519Scalar,
     };
     use alloc::vec::Vec;

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -137,6 +137,7 @@ impl ColumnCommitmentMetadataMapExt for ColumnCommitmentMetadataMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
         database::{owned_table_utility::*, ColumnType, OwnedTable},
@@ -144,7 +145,6 @@ mod tests {
     };
     use alloc::vec::Vec;
     use itertools::Itertools;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     fn metadata_map_from_owned_table(
         table: OwnedTable<Curve25519Scalar>,

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -360,9 +360,11 @@ mod tests {
         scalar::Curve25519Scalar,
     };
     use curve25519_dalek::RistrettoPoint;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {
+        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // empty case
         let column_commitments =
             ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset::<
@@ -415,7 +417,7 @@ mod tests {
                 .get_metadata(&bigint_id)
                 .unwrap()
                 .column_type(),
-            &ColumnType::BigInt
+            &ColumnType::BigInt(col_meta)
         );
         assert_eq!(
             column_commitments.get_commitment(&bigint_id).unwrap(),
@@ -427,7 +429,7 @@ mod tests {
                 .get_metadata(&varchar_id)
                 .unwrap()
                 .column_type(),
-            &ColumnType::VarChar
+            &ColumnType::VarChar(col_meta)
         );
         assert_eq!(
             column_commitments.get_commitment(&varchar_id).unwrap(),
@@ -439,7 +441,7 @@ mod tests {
                 .get_metadata(&scalar_id)
                 .unwrap()
                 .column_type(),
-            &ColumnType::Scalar
+            &ColumnType::Scalar(col_meta)
         );
         assert_eq!(
             column_commitments.get_commitment(&scalar_id).unwrap(),
@@ -482,7 +484,7 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![]);
+        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
 
         let from_columns_result = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -547,6 +549,7 @@ mod tests {
 
     #[test]
     fn we_can_iterate_over_column_commitments() {
+        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let varchar_id: Identifier = "varchar_column".parse().unwrap();
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
@@ -573,17 +576,17 @@ mod tests {
         let (identifier, metadata, commitment) = iterator.next().unwrap();
         assert_eq!(commitment, &expected_commitments[0]);
         assert_eq!(identifier, &bigint_id);
-        assert_eq!(metadata.column_type(), &ColumnType::BigInt);
+        assert_eq!(metadata.column_type(), &ColumnType::BigInt(col_meta));
 
         let (identifier, metadata, commitment) = iterator.next().unwrap();
         assert_eq!(commitment, &expected_commitments[1]);
         assert_eq!(identifier, &varchar_id);
-        assert_eq!(metadata.column_type(), &ColumnType::VarChar);
+        assert_eq!(metadata.column_type(), &ColumnType::VarChar(col_meta));
 
         let (identifier, metadata, commitment) = iterator.next().unwrap();
         assert_eq!(commitment, &expected_commitments[2]);
         assert_eq!(identifier, &scalar_id);
-        assert_eq!(metadata.column_type(), &ColumnType::Scalar);
+        assert_eq!(metadata.column_type(), &ColumnType::Scalar(col_meta));
     }
 
     #[test]
@@ -823,6 +826,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_column_commitments() {
+        let col_meta =ColumnTypeAssociatedData::NOT_NULLABLE;
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let bigint_data = [1i64, 5, -5, 0, 10];
 
@@ -885,18 +889,18 @@ mod tests {
         );
 
         let bigint_metadata = actual_difference.get_metadata(&bigint_id).unwrap();
-        assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt);
+        assert_eq!(bigint_metadata.column_type(), &ColumnType::BigInt(col_meta));
         if let ColumnBounds::BigInt(Bounds::Bounded(bounds)) = bigint_metadata.bounds() {
             assert_eq!(bounds.min(), &-5);
             assert_eq!(bounds.max(), &10);
         }
 
         let varchar_metadata = actual_difference.get_metadata(&varchar_id).unwrap();
-        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar);
+        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar(col_meta));
         assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
 
         let scalar_metadata = actual_difference.get_metadata(&scalar_id).unwrap();
-        assert_eq!(scalar_metadata.column_type(), &ColumnType::Scalar);
+        assert_eq!(scalar_metadata.column_type(), &ColumnType::Scalar(col_meta));
         assert_eq!(scalar_metadata.bounds(), &ColumnBounds::NoOrder);
     }
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -354,10 +354,11 @@ impl<C> FromIterator<(Identifier, ColumnCommitmentMetadata, C)> for ColumnCommit
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
-        database::{owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable},
+        database::{
+            owned_table_utility::*, ColumnType, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+        },
         scalar::Curve25519Scalar,
     };
     use curve25519_dalek::RistrettoPoint;

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -357,7 +357,7 @@ mod tests {
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
         database::{
-            owned_table_utility::*, ColumnType, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+            owned_table_utility::*, ColumnNullability, ColumnType, OwnedColumn, OwnedTable,
         },
         scalar::Curve25519Scalar,
     };
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {
-        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnNullability::NotNullable;
         // empty case
         let column_commitments =
             ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset::<
@@ -486,7 +486,7 @@ mod tests {
         let unique_identifier = "unique_identifier".parse().unwrap();
 
         let empty_column =
-            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![]);
 
         let from_columns_result = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn we_can_iterate_over_column_commitments() {
-        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnNullability::NotNullable;
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let varchar_id: Identifier = "varchar_column".parse().unwrap();
         let scalar_id: Identifier = "scalar_column".parse().unwrap();
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_column_commitments() {
-        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnNullability::NotNullable;
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let bigint_data = [1i64, 5, -5, 0, 10];
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -354,13 +354,13 @@ impl<C> FromIterator<(Identifier, ColumnCommitmentMetadata, C)> for ColumnCommit
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         commitment::{column_bounds::Bounds, ColumnBounds},
         database::{owned_table_utility::*, ColumnType, OwnedColumn, OwnedTable},
         scalar::Curve25519Scalar,
     };
     use curve25519_dalek::RistrettoPoint;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_column_commitments_from_columns_and_identifiers() {
@@ -484,7 +484,8 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
+        let empty_column =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
 
         let from_columns_result = ColumnCommitments::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -826,7 +827,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_column_commitments() {
-        let col_meta =ColumnTypeAssociatedData::NOT_NULLABLE;
+        let col_meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let bigint_id: Identifier = "bigint_column".parse().unwrap();
         let bigint_data = [1i64, 5, -5, 0, 10];
 
@@ -896,7 +897,10 @@ mod tests {
         }
 
         let varchar_metadata = actual_difference.get_metadata(&varchar_id).unwrap();
-        assert_eq!(varchar_metadata.column_type(), &ColumnType::VarChar(col_meta));
+        assert_eq!(
+            varchar_metadata.column_type(),
+            &ColumnType::VarChar(col_meta)
+        );
         assert_eq!(varchar_metadata.bounds(), &ColumnBounds::NoOrder);
 
         let scalar_metadata = actual_difference.get_metadata(&scalar_id).unwrap();

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -1,6 +1,8 @@
 use super::CommitmentEvaluationProof;
-use crate::base::database::ColumnTypeAssociatedData;
-use crate::base::{commitment::vec_commitment_ext::VecCommitmentExt, database::Column};
+use crate::base::{
+    commitment::vec_commitment_ext::VecCommitmentExt,
+    database::{Column, ColumnTypeAssociatedData},
+};
 use ark_std::UniformRand;
 #[cfg(feature = "blitzar")]
 use blitzar::proof::InnerProductProof;

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -1,11 +1,11 @@
 use super::CommitmentEvaluationProof;
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{commitment::vec_commitment_ext::VecCommitmentExt, database::Column};
 use ark_std::UniformRand;
 #[cfg(feature = "blitzar")]
 use blitzar::proof::InnerProductProof;
 use merlin::Transcript;
 use num_traits::{One, Zero};
-use crate::base::database::ColumnTypeAssociatedData;
 
 pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     prover_setup: &CP::ProverPublicSetup<'_>,
@@ -21,10 +21,10 @@ pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     );
 
     let commits = Vec::from_columns_with_offset(
-        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[
-            CP::Scalar::one(),
-            CP::Scalar::one() + CP::Scalar::one(),
-        ])],
+        [Column::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[CP::Scalar::one(), CP::Scalar::one() + CP::Scalar::one()],
+        )],
         0,
         prover_setup,
     );
@@ -51,7 +51,11 @@ pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationPr
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &[r], &[], 0, prover_setup);
 
-    let commits = Vec::from_columns_with_offset([Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[r])], 0, prover_setup);
+    let commits = Vec::from_columns_with_offset(
+        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[r])],
+        0,
+        prover_setup,
+    );
 
     let mut transcript = Transcript::new(b"evaluation_proof");
     let r = proof.verify_proof(&mut transcript, &commits[0], &r, &[], 0, 1, verifier_setup);
@@ -79,7 +83,11 @@ pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &a, &b_point, offset as u64, prover_setup);
 
-    let commits = Vec::from_columns_with_offset([Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &a)], offset, prover_setup);
+    let commits = Vec::from_columns_with_offset(
+        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &a)],
+        offset,
+        prover_setup,
+    );
 
     let mut b = vec![CP::Scalar::zero(); a.len()];
     crate::base::polynomial::compute_evaluation_vector(&mut b, &b_point);

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -5,6 +5,7 @@ use ark_std::UniformRand;
 use blitzar::proof::InnerProductProof;
 use merlin::Transcript;
 use num_traits::{One, Zero};
+use crate::base::database::ColumnTypeAssociatedData;
 
 pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     prover_setup: &CP::ProverPublicSetup<'_>,
@@ -20,7 +21,7 @@ pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     );
 
     let commits = Vec::from_columns_with_offset(
-        [Column::Scalar(&[
+        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[
             CP::Scalar::one(),
             CP::Scalar::one() + CP::Scalar::one(),
         ])],
@@ -50,7 +51,7 @@ pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationPr
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &[r], &[], 0, prover_setup);
 
-    let commits = Vec::from_columns_with_offset([Column::Scalar(&[r])], 0, prover_setup);
+    let commits = Vec::from_columns_with_offset([Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[r])], 0, prover_setup);
 
     let mut transcript = Transcript::new(b"evaluation_proof");
     let r = proof.verify_proof(&mut transcript, &commits[0], &r, &[], 0, 1, verifier_setup);
@@ -78,7 +79,7 @@ pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &a, &b_point, offset as u64, prover_setup);
 
-    let commits = Vec::from_columns_with_offset([Column::Scalar(&a)], offset, prover_setup);
+    let commits = Vec::from_columns_with_offset([Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &a)], offset, prover_setup);
 
     let mut b = vec![CP::Scalar::zero(); a.len()];
     crate::base::polynomial::compute_evaluation_vector(&mut b, &b_point);

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -1,7 +1,7 @@
 use super::CommitmentEvaluationProof;
 use crate::base::{
     commitment::vec_commitment_ext::VecCommitmentExt,
-    database::{Column, ColumnTypeAssociatedData},
+    database::{Column, ColumnNullability},
 };
 use ark_std::UniformRand;
 #[cfg(feature = "blitzar")]
@@ -24,7 +24,7 @@ pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
 
     let commits = Vec::from_columns_with_offset(
         [Column::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[CP::Scalar::one(), CP::Scalar::one() + CP::Scalar::one()],
         )],
         0,
@@ -54,7 +54,7 @@ pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationPr
     let proof = CP::new(&mut transcript, &[r], &[], 0, prover_setup);
 
     let commits = Vec::from_columns_with_offset(
-        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &[r])],
+        [Column::Scalar(ColumnNullability::NotNullable, &[r])],
         0,
         prover_setup,
     );
@@ -86,7 +86,7 @@ pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     let proof = CP::new(&mut transcript, &a, &b_point, offset as u64, prover_setup);
 
     let commits = Vec::from_columns_with_offset(
-        [Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &a)],
+        [Column::Scalar(ColumnNullability::NotNullable, &a)],
         offset,
         prover_setup,
     );

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{Column, ColumnType, OwnedColumn},
     math::decimal::Precision,
@@ -8,7 +9,6 @@ use alloc::vec::Vec;
 #[cfg(feature = "blitzar")]
 use blitzar::sequence::Sequence;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Column data in "committable form".
 ///
@@ -83,20 +83,34 @@ impl<'a> CommittableColumn<'a> {
 impl<'a> From<&CommittableColumn<'a>> for ColumnType {
     fn from(value: &CommittableColumn<'a>) -> Self {
         match value {
-            CommittableColumn::TinyInt(_) => ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::SmallInt(_) => ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            CommittableColumn::TinyInt(_) => {
+                ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
+            CommittableColumn::SmallInt(_) => {
+                ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
             CommittableColumn::Int(_) => ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::BigInt(_) => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::Int128(_) => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            CommittableColumn::BigInt(_) => {
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
+            CommittableColumn::Int128(_) => {
+                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
             CommittableColumn::Decimal75(precision, scale, _) => {
                 ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, *precision, *scale)
             }
-            CommittableColumn::Scalar(_) => ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::VarChar(_) => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::Boolean(_) => ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                *tu, *tz),
+            CommittableColumn::Scalar(_) => {
+                ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
+            CommittableColumn::VarChar(_) => {
+                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
+            CommittableColumn::Boolean(_) => {
+                ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
+            CommittableColumn::TimestampTZ(tu, tz, _) => {
+                ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, *tu, *tz)
+            }
             CommittableColumn::RangeCheckWord(_) => {
                 unimplemented!("Range check words are not a column type.")
             }
@@ -122,7 +136,9 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
-            Column::TimestampTZ(_, tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
+            Column::TimestampTZ(_, tu, tz, times) => {
+                CommittableColumn::TimestampTZ(*tu, *tz, times)
+            }
         }
     }
 }
@@ -242,7 +258,12 @@ mod tests {
             Curve25519Scalar::from(1),
             Curve25519Scalar::from(2),
         ];
-        let decimal_column = OwnedColumn::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, Precision::new(75).unwrap(), -1, decimals);
+        let decimal_column = OwnedColumn::Decimal75(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            Precision::new(75).unwrap(),
+            -1,
+            decimals,
+        );
 
         let res_committable_column: CommittableColumn = (&decimal_column).into();
         let test_committable_column: CommittableColumn = CommittableColumn::Decimal75(
@@ -266,7 +287,11 @@ mod tests {
         assert!(committable_column.is_empty());
         assert_eq!(
             committable_column.column_type(),
-            ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc)
+            ColumnType::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc
+            )
         );
 
         let committable_column = CommittableColumn::TimestampTZ(
@@ -278,7 +303,11 @@ mod tests {
         assert!(!committable_column.is_empty());
         assert_eq!(
             committable_column.column_type(),
-            ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc)
+            ColumnType::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc
+            )
         );
     }
 
@@ -328,12 +357,18 @@ mod tests {
         let int_committable_column = CommittableColumn::Int(&[]);
         assert_eq!(int_committable_column.len(), 0);
         assert!(int_committable_column.is_empty());
-        assert_eq!(int_committable_column.column_type(), ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            int_committable_column.column_type(),
+            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let int_committable_column = CommittableColumn::Int(&[12, 34, 56]);
         assert_eq!(int_committable_column.len(), 3);
         assert!(!int_committable_column.is_empty());
-        assert_eq!(int_committable_column.column_type(), ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            int_committable_column.column_type(),
+            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -342,12 +377,18 @@ mod tests {
         let bigint_committable_column = CommittableColumn::BigInt(&[]);
         assert_eq!(bigint_committable_column.len(), 0);
         assert!(bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let bigint_committable_column = CommittableColumn::BigInt(&[12, 34, 56]);
         assert_eq!(bigint_committable_column.len(), 3);
         assert!(!bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -359,7 +400,11 @@ mod tests {
         assert!(decimal_committable_column.is_empty());
         assert_eq!(
             decimal_committable_column.column_type(),
-            ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, Precision::new(1).unwrap(), 0)
+            ColumnType::Decimal75(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                Precision::new(1).unwrap(),
+                0
+            )
         );
         let decimal_committable_column = CommittableColumn::Decimal75(
             Precision::new(10).unwrap(),
@@ -370,8 +415,11 @@ mod tests {
         assert!(!decimal_committable_column.is_empty());
         assert_eq!(
             decimal_committable_column.column_type(),
-            ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE,
-                                  Precision::new(10).unwrap(), 10)
+            ColumnType::Decimal75(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                Precision::new(10).unwrap(),
+                10
+            )
         );
     }
 
@@ -381,12 +429,18 @@ mod tests {
         let bigint_committable_column = CommittableColumn::Int128(&[]);
         assert_eq!(bigint_committable_column.len(), 0);
         assert!(bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let bigint_committable_column = CommittableColumn::Int128(&[12, 34, 56]);
         assert_eq!(bigint_committable_column.len(), 3);
         assert!(!bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -395,7 +449,10 @@ mod tests {
         let bigint_committable_column = CommittableColumn::VarChar(Vec::new());
         assert_eq!(bigint_committable_column.len(), 0);
         assert!(bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let bigint_committable_column = CommittableColumn::VarChar(
             ["12", "34", "56"]
@@ -406,7 +463,10 @@ mod tests {
         );
         assert_eq!(bigint_committable_column.len(), 3);
         assert!(!bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -415,7 +475,10 @@ mod tests {
         let bigint_committable_column = CommittableColumn::Scalar(Vec::new());
         assert_eq!(bigint_committable_column.len(), 0);
         assert!(bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let bigint_committable_column = CommittableColumn::Scalar(
             [12, 34, 56]
@@ -425,7 +488,10 @@ mod tests {
         );
         assert_eq!(bigint_committable_column.len(), 3);
         assert!(!bigint_committable_column.is_empty());
-        assert_eq!(bigint_committable_column.column_type(), ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bigint_committable_column.column_type(),
+            ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -434,12 +500,18 @@ mod tests {
         let bool_committable_column = CommittableColumn::Boolean(&[]);
         assert_eq!(bool_committable_column.len(), 0);
         assert!(bool_committable_column.is_empty());
-        assert_eq!(bool_committable_column.column_type(), ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bool_committable_column.column_type(),
+            ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
 
         let bool_committable_column = CommittableColumn::Boolean(&[true, false, true]);
         assert_eq!(bool_committable_column.len(), 3);
         assert!(!bool_committable_column.is_empty());
-        assert_eq!(bool_committable_column.column_type(), ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE));
+        assert_eq!(
+            bool_committable_column.column_type(),
+            ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
     }
 
     #[test]
@@ -487,13 +559,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_bigint_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::BigInt(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE,
-                                                                        &[12, 34, 56]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[12, 34, 56],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::BigInt(&[12, 34, 56])
@@ -503,15 +578,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_tinyint_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::TinyInt(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[12, 34, 56])
-            );
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[12, 34, 56],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::TinyInt(&[12, 34, 56])
@@ -521,18 +597,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_smallint_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[])
-            );
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::SmallInt(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[12, 34, 56])
-            );
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[12, 34, 56],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::SmallInt(&[12, 34, 56])
@@ -544,15 +618,14 @@ mod tests {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            &[]
+            &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[12, 34, 56]
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[12, 34, 56],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[12, 34, 56]));
     }
 
@@ -566,8 +639,12 @@ mod tests {
         ];
 
         let precision = Precision::new(75).unwrap();
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, precision, 0, &binding));
+        let from_borrowed_column = CommittableColumn::from(&Column::Decimal75(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            precision,
+            0,
+            &binding,
+        ));
 
         let expected_decimals = binding
             .iter()
@@ -583,15 +660,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_int128_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int128(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[12, 34, 56]
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[12, 34, 56],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::Int128(&[12, 34, 56])
@@ -601,14 +679,18 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_varchar_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[])));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            (&[], &[]),
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::VarChar(Vec::new()));
 
         let varchar_data = ["12", "34", "56"];
         let scalars = varchar_data.map(Curve25519Scalar::from);
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&varchar_data, &scalars)));
+        let from_borrowed_column = CommittableColumn::from(&Column::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            (&varchar_data, &scalars),
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::VarChar(scalars.map(<[u64; 4]>::from).into())
@@ -618,17 +700,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_scalar_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Scalar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[])
-            );
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::Scalar(Vec::new()));
 
         let scalars = [12, 34, 56].map(Curve25519Scalar::from);
         let from_borrowed_column = CommittableColumn::from(&Column::Scalar(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            &scalars
+            &scalars,
         ));
         assert_eq!(
             from_borrowed_column,
@@ -639,18 +720,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_borrowing_boolean_column() {
         // empty case
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[]
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[],
+        ));
         assert_eq!(from_borrowed_column, CommittableColumn::Boolean(&[]));
 
-        let from_borrowed_column =
-            CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                &[true, false, true]
-            ));
+        let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[true, false, true],
+        ));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::Boolean(&[true, false, true])
@@ -662,12 +741,15 @@ mod tests {
         // empty case
         let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new()
+            Vec::new(),
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::BigInt(&[]));
 
-        let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![12, 34, 56]);
+        let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![12, 34, 56],
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::BigInt(&[12, 34, 56]));
     }
@@ -675,11 +757,15 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_tinyint_column() {
         // empty case
-        let owned_column = OwnedColumn::<DoryScalar>::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+        let owned_column =
+            OwnedColumn::<DoryScalar>::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::TinyInt(&[]));
 
-        let owned_column = OwnedColumn::<DoryScalar>::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![12, 34, 56]);
+        let owned_column = OwnedColumn::<DoryScalar>::TinyInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![12, 34, 56],
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::TinyInt(&[12, 34, 56]));
     }
@@ -687,13 +773,14 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_smallint_column() {
         // empty case
-        let owned_column = OwnedColumn::<DoryScalar>::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE,Vec::new());
+        let owned_column =
+            OwnedColumn::<DoryScalar>::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::SmallInt(&[]));
 
         let owned_column = OwnedColumn::<DoryScalar>::SmallInt(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-           vec![12, 34, 56]
+            vec![12, 34, 56],
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
@@ -735,16 +822,14 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_int_column() {
         // empty case
-        let owned_column = OwnedColumn::<DoryScalar>::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new()
-        );
+        let owned_column =
+            OwnedColumn::<DoryScalar>::Int(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int(&[]));
 
         let owned_column = OwnedColumn::<DoryScalar>::Int(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![12, 34, 56]
+            vec![12, 34, 56],
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int(&[12, 34, 56]));
@@ -753,11 +838,17 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_int128_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            Vec::new(),
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int128(&[]));
 
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, vec![12, 34, 56]);
+        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![12, 34, 56],
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int128(&[12, 34, 56]));
     }
@@ -765,12 +856,18 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_varchar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            Vec::new(),
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::VarChar(Vec::new()));
 
         let strings = ["12", "34", "56"].map(String::from);
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, strings.to_vec());
+        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            strings.to_vec(),
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
@@ -786,12 +883,16 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_scalar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+        let owned_column = OwnedColumn::<Curve25519Scalar>::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            Vec::new(),
+        );
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Scalar(Vec::new()));
 
         let scalars = [12, 34, 56].map(Curve25519Scalar::from);
-        let owned_column = OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, scalars.to_vec());
+        let owned_column =
+            OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, scalars.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
@@ -802,15 +903,14 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_boolean_column() {
         // empty case
-        let owned_column = OwnedColumn::<DoryScalar>::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+        let owned_column =
+            OwnedColumn::<DoryScalar>::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Boolean(&[]));
 
         let booleans = [true, false, true];
-        let owned_column: OwnedColumn<DoryScalar> = OwnedColumn::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            booleans.to_vec()
-        );
+        let owned_column: OwnedColumn<DoryScalar> =
+            OwnedColumn::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, booleans.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Boolean(&booleans));
     }
@@ -1005,7 +1105,7 @@ mod tests {
         let values = ["12", "34", "56"].map(String::from);
         let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            values.to_vec()
+            values.to_vec(),
         );
         let committable_column = CommittableColumn::from(&owned_column);
 
@@ -1032,7 +1132,8 @@ mod tests {
 
         // nonempty case
         let values = [12, 34, 56].map(Curve25519Scalar::from);
-        let owned_column = OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, values.to_vec());
+        let owned_column =
+            OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, values.to_vec());
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    database::{Column, ColumnType, ColumnTypeAssociatedData, OwnedColumn},
+    database::{Column, ColumnNullability, ColumnType, OwnedColumn},
     math::decimal::Precision,
     ref_into::RefInto,
     scalar::Scalar,
@@ -82,33 +82,19 @@ impl<'a> CommittableColumn<'a> {
 impl<'a> From<&CommittableColumn<'a>> for ColumnType {
     fn from(value: &CommittableColumn<'a>) -> Self {
         match value {
-            CommittableColumn::TinyInt(_) => {
-                ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
-            CommittableColumn::SmallInt(_) => {
-                ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
-            CommittableColumn::Int(_) => ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE),
-            CommittableColumn::BigInt(_) => {
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
-            CommittableColumn::Int128(_) => {
-                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
+            CommittableColumn::TinyInt(_) => ColumnType::TinyInt(ColumnNullability::NotNullable),
+            CommittableColumn::SmallInt(_) => ColumnType::SmallInt(ColumnNullability::NotNullable),
+            CommittableColumn::Int(_) => ColumnType::Int(ColumnNullability::NotNullable),
+            CommittableColumn::BigInt(_) => ColumnType::BigInt(ColumnNullability::NotNullable),
+            CommittableColumn::Int128(_) => ColumnType::Int128(ColumnNullability::NotNullable),
             CommittableColumn::Decimal75(precision, scale, _) => {
-                ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, *precision, *scale)
+                ColumnType::Decimal75(ColumnNullability::NotNullable, *precision, *scale)
             }
-            CommittableColumn::Scalar(_) => {
-                ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
-            CommittableColumn::VarChar(_) => {
-                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
-            CommittableColumn::Boolean(_) => {
-                ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
+            CommittableColumn::Scalar(_) => ColumnType::Scalar(ColumnNullability::NotNullable),
+            CommittableColumn::VarChar(_) => ColumnType::VarChar(ColumnNullability::NotNullable),
+            CommittableColumn::Boolean(_) => ColumnType::Boolean(ColumnNullability::NotNullable),
             CommittableColumn::TimestampTZ(tu, tz, _) => {
-                ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, *tu, *tz)
+                ColumnType::TimestampTZ(ColumnNullability::NotNullable, *tu, *tz)
             }
             CommittableColumn::RangeCheckWord(_) => {
                 unimplemented!("Range check words are not a column type.")
@@ -258,7 +244,7 @@ mod tests {
             Curve25519Scalar::from(2),
         ];
         let decimal_column = OwnedColumn::Decimal75(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             Precision::new(75).unwrap(),
             -1,
             decimals,
@@ -287,7 +273,7 @@ mod tests {
         assert_eq!(
             committable_column.column_type(),
             ColumnType::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc
             )
@@ -303,7 +289,7 @@ mod tests {
         assert_eq!(
             committable_column.column_type(),
             ColumnType::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc
             )
@@ -318,7 +304,7 @@ mod tests {
         assert!(tinyint_committable_column.is_empty());
         assert_eq!(
             tinyint_committable_column.column_type(),
-            ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::TinyInt(ColumnNullability::NotNullable)
         );
 
         let tinyint_committable_column = CommittableColumn::TinyInt(&[12, 34, 56]);
@@ -326,7 +312,7 @@ mod tests {
         assert!(!tinyint_committable_column.is_empty());
         assert_eq!(
             tinyint_committable_column.column_type(),
-            ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::TinyInt(ColumnNullability::NotNullable)
         );
     }
 
@@ -338,7 +324,7 @@ mod tests {
         assert!(smallint_committable_column.is_empty());
         assert_eq!(
             smallint_committable_column.column_type(),
-            ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::SmallInt(ColumnNullability::NotNullable)
         );
 
         let smallint_committable_column = CommittableColumn::SmallInt(&[12, 34, 56]);
@@ -346,7 +332,7 @@ mod tests {
         assert!(!smallint_committable_column.is_empty());
         assert_eq!(
             smallint_committable_column.column_type(),
-            ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::SmallInt(ColumnNullability::NotNullable)
         );
     }
 
@@ -358,7 +344,7 @@ mod tests {
         assert!(int_committable_column.is_empty());
         assert_eq!(
             int_committable_column.column_type(),
-            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int(ColumnNullability::NotNullable)
         );
 
         let int_committable_column = CommittableColumn::Int(&[12, 34, 56]);
@@ -366,7 +352,7 @@ mod tests {
         assert!(!int_committable_column.is_empty());
         assert_eq!(
             int_committable_column.column_type(),
-            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int(ColumnNullability::NotNullable)
         );
     }
 
@@ -378,7 +364,7 @@ mod tests {
         assert!(bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::BigInt(ColumnNullability::NotNullable)
         );
 
         let bigint_committable_column = CommittableColumn::BigInt(&[12, 34, 56]);
@@ -386,7 +372,7 @@ mod tests {
         assert!(!bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::BigInt(ColumnNullability::NotNullable)
         );
     }
 
@@ -400,7 +386,7 @@ mod tests {
         assert_eq!(
             decimal_committable_column.column_type(),
             ColumnType::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 Precision::new(1).unwrap(),
                 0
             )
@@ -415,7 +401,7 @@ mod tests {
         assert_eq!(
             decimal_committable_column.column_type(),
             ColumnType::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 Precision::new(10).unwrap(),
                 10
             )
@@ -430,7 +416,7 @@ mod tests {
         assert!(bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int128(ColumnNullability::NotNullable)
         );
 
         let bigint_committable_column = CommittableColumn::Int128(&[12, 34, 56]);
@@ -438,7 +424,7 @@ mod tests {
         assert!(!bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int128(ColumnNullability::NotNullable)
         );
     }
 
@@ -450,7 +436,7 @@ mod tests {
         assert!(bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::VarChar(ColumnNullability::NotNullable)
         );
 
         let bigint_committable_column = CommittableColumn::VarChar(
@@ -464,7 +450,7 @@ mod tests {
         assert!(!bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::VarChar(ColumnNullability::NotNullable)
         );
     }
 
@@ -476,7 +462,7 @@ mod tests {
         assert!(bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Scalar(ColumnNullability::NotNullable)
         );
 
         let bigint_committable_column = CommittableColumn::Scalar(
@@ -489,7 +475,7 @@ mod tests {
         assert!(!bigint_committable_column.is_empty());
         assert_eq!(
             bigint_committable_column.column_type(),
-            ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Scalar(ColumnNullability::NotNullable)
         );
     }
 
@@ -501,7 +487,7 @@ mod tests {
         assert!(bool_committable_column.is_empty());
         assert_eq!(
             bool_committable_column.column_type(),
-            ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Boolean(ColumnNullability::NotNullable)
         );
 
         let bool_committable_column = CommittableColumn::Boolean(&[true, false, true]);
@@ -509,7 +495,7 @@ mod tests {
         assert!(!bool_committable_column.is_empty());
         assert_eq!(
             bool_committable_column.column_type(),
-            ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Boolean(ColumnNullability::NotNullable)
         );
     }
 
@@ -530,7 +516,7 @@ mod tests {
         // empty case
         let from_borrowed_column =
             CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &[],
@@ -544,7 +530,7 @@ mod tests {
         let timestamps = [1_625_072_400, 1_625_076_000, 1_625_083_200];
         let from_borrowed_column =
             CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &timestamps,
@@ -559,13 +545,13 @@ mod tests {
     fn we_can_convert_from_borrowing_bigint_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::BigInt(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[12, 34, 56],
         ));
         assert_eq!(
@@ -578,13 +564,13 @@ mod tests {
     fn we_can_convert_from_borrowing_tinyint_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::TinyInt(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::TinyInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[12, 34, 56],
         ));
         assert_eq!(
@@ -597,13 +583,13 @@ mod tests {
     fn we_can_convert_from_borrowing_smallint_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::SmallInt(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::SmallInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[12, 34, 56],
         ));
         assert_eq!(
@@ -616,13 +602,13 @@ mod tests {
     fn we_can_convert_from_borrowing_int_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[12, 34, 56],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int(&[12, 34, 56]));
@@ -639,7 +625,7 @@ mod tests {
 
         let precision = Precision::new(75).unwrap();
         let from_borrowed_column = CommittableColumn::from(&Column::Decimal75(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             precision,
             0,
             &binding,
@@ -660,13 +646,13 @@ mod tests {
     fn we_can_convert_from_borrowing_int128_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Int128(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[12, 34, 56],
         ));
         assert_eq!(
@@ -679,7 +665,7 @@ mod tests {
     fn we_can_convert_from_borrowing_varchar_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             (&[], &[]),
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::VarChar(Vec::new()));
@@ -687,7 +673,7 @@ mod tests {
         let varchar_data = ["12", "34", "56"];
         let scalars = varchar_data.map(Curve25519Scalar::from);
         let from_borrowed_column = CommittableColumn::from(&Column::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             (&varchar_data, &scalars),
         ));
         assert_eq!(
@@ -700,16 +686,14 @@ mod tests {
     fn we_can_convert_from_borrowing_scalar_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Scalar(Vec::new()));
 
         let scalars = [12, 34, 56].map(Curve25519Scalar::from);
-        let from_borrowed_column = CommittableColumn::from(&Column::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            &scalars,
-        ));
+        let from_borrowed_column =
+            CommittableColumn::from(&Column::Scalar(ColumnNullability::NotNullable, &scalars));
         assert_eq!(
             from_borrowed_column,
             CommittableColumn::Scalar(scalars.map(<[u64; 4]>::from).into())
@@ -720,13 +704,13 @@ mod tests {
     fn we_can_convert_from_borrowing_boolean_column() {
         // empty case
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[],
         ));
         assert_eq!(from_borrowed_column, CommittableColumn::Boolean(&[]));
 
         let from_borrowed_column = CommittableColumn::from(&Column::<Curve25519Scalar>::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             &[true, false, true],
         ));
         assert_eq!(
@@ -738,15 +722,13 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_bigint_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new(),
-        );
+        let owned_column =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::BigInt(&[]));
 
         let owned_column = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             vec![12, 34, 56],
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
@@ -757,14 +739,12 @@ mod tests {
     fn we_can_convert_from_owned_tinyint_column() {
         // empty case
         let owned_column =
-            OwnedColumn::<DoryScalar>::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+            OwnedColumn::<DoryScalar>::TinyInt(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::TinyInt(&[]));
 
-        let owned_column = OwnedColumn::<DoryScalar>::TinyInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![12, 34, 56],
-        );
+        let owned_column =
+            OwnedColumn::<DoryScalar>::TinyInt(ColumnNullability::NotNullable, vec![12, 34, 56]);
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::TinyInt(&[12, 34, 56]));
     }
@@ -773,14 +753,12 @@ mod tests {
     fn we_can_convert_from_owned_smallint_column() {
         // empty case
         let owned_column =
-            OwnedColumn::<DoryScalar>::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+            OwnedColumn::<DoryScalar>::SmallInt(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::SmallInt(&[]));
 
-        let owned_column = OwnedColumn::<DoryScalar>::SmallInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![12, 34, 56],
-        );
+        let owned_column =
+            OwnedColumn::<DoryScalar>::SmallInt(ColumnNullability::NotNullable, vec![12, 34, 56]);
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
@@ -792,7 +770,7 @@ mod tests {
     fn we_can_convert_from_owned_timestamp_column() {
         // empty case
         let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             Vec::new(),
@@ -806,7 +784,7 @@ mod tests {
         // non-empty case
         let timestamps = vec![1_625_072_400, 1_625_076_000, 1_625_083_200];
         let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             timestamps.clone(),
@@ -822,14 +800,12 @@ mod tests {
     fn we_can_convert_from_owned_int_column() {
         // empty case
         let owned_column =
-            OwnedColumn::<DoryScalar>::Int(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+            OwnedColumn::<DoryScalar>::Int(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int(&[]));
 
-        let owned_column = OwnedColumn::<DoryScalar>::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![12, 34, 56],
-        );
+        let owned_column =
+            OwnedColumn::<DoryScalar>::Int(ColumnNullability::NotNullable, vec![12, 34, 56]);
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int(&[12, 34, 56]));
     }
@@ -837,15 +813,13 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_int128_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new(),
-        );
+        let owned_column =
+            OwnedColumn::<Curve25519Scalar>::Int128(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Int128(&[]));
 
         let owned_column = OwnedColumn::<Curve25519Scalar>::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             vec![12, 34, 56],
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
@@ -855,16 +829,14 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_varchar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new(),
-        );
+        let owned_column =
+            OwnedColumn::<Curve25519Scalar>::VarChar(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::VarChar(Vec::new()));
 
         let strings = ["12", "34", "56"].map(String::from);
         let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             strings.to_vec(),
         );
         let from_owned_column = CommittableColumn::from(&owned_column);
@@ -882,16 +854,13 @@ mod tests {
     #[test]
     fn we_can_convert_from_owned_scalar_column() {
         // empty case
-        let owned_column = OwnedColumn::<Curve25519Scalar>::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            Vec::new(),
-        );
+        let owned_column =
+            OwnedColumn::<Curve25519Scalar>::Scalar(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Scalar(Vec::new()));
 
         let scalars = [12, 34, 56].map(Curve25519Scalar::from);
-        let owned_column =
-            OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, scalars.to_vec());
+        let owned_column = OwnedColumn::Scalar(ColumnNullability::NotNullable, scalars.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(
             from_owned_column,
@@ -903,13 +872,13 @@ mod tests {
     fn we_can_convert_from_owned_boolean_column() {
         // empty case
         let owned_column =
-            OwnedColumn::<DoryScalar>::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, Vec::new());
+            OwnedColumn::<DoryScalar>::Boolean(ColumnNullability::NotNullable, Vec::new());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Boolean(&[]));
 
         let booleans = [true, false, true];
         let owned_column: OwnedColumn<DoryScalar> =
-            OwnedColumn::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, booleans.to_vec());
+            OwnedColumn::Boolean(ColumnNullability::NotNullable, booleans.to_vec());
         let from_owned_column = CommittableColumn::from(&owned_column);
         assert_eq!(from_owned_column, CommittableColumn::Boolean(&booleans));
     }
@@ -1103,7 +1072,7 @@ mod tests {
         // nonempty case
         let values = ["12", "34", "56"].map(String::from);
         let owned_column = OwnedColumn::<Curve25519Scalar>::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             values.to_vec(),
         );
         let committable_column = CommittableColumn::from(&owned_column);
@@ -1131,8 +1100,7 @@ mod tests {
 
         // nonempty case
         let values = [12, 34, 56].map(Curve25519Scalar::from);
-        let owned_column =
-            OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, values.to_vec());
+        let owned_column = OwnedColumn::Scalar(ColumnNullability::NotNullable, values.to_vec());
         let committable_column = CommittableColumn::from(&owned_column);
 
         let sequence_actual = Sequence::from(&committable_column);

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -1,6 +1,5 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
-    database::{Column, ColumnType, OwnedColumn},
+    database::{Column, ColumnType, ColumnTypeAssociatedData, OwnedColumn},
     math::decimal::Precision,
     ref_into::RefInto,
     scalar::Scalar,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -132,7 +132,7 @@ mod tests {
         base::{
             commitment::{Bounds, ColumnBounds},
             database::{
-                owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+                owned_table_utility::*, ColumnNullability, OwnedColumn, OwnedTable,
                 OwnedTableTestAccessor, TestAccessor,
             },
             scalar::Curve25519Scalar,
@@ -171,10 +171,7 @@ mod tests {
         let no_rows_commitment = TableCommitment::try_from_columns_with_offset(
             [(
                 &"column_c".parse().unwrap(),
-                &OwnedColumn::<Curve25519Scalar>::BigInt(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    vec![],
-                ),
+                &OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![]),
             )],
             3,
             &(),
@@ -205,7 +202,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_commitment_of_a_column() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
@@ -256,7 +253,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_schema_of_tables() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
@@ -332,7 +329,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 3);

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -128,6 +128,7 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
             commitment::{Bounds, ColumnBounds},
@@ -143,7 +144,6 @@ mod tests {
         },
     };
     use curve25519_dalek::RistrettoPoint;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_get_length_and_offset_of_tables() {
@@ -172,7 +172,10 @@ mod tests {
         let no_rows_commitment = TableCommitment::try_from_columns_with_offset(
             [(
                 &"column_c".parse().unwrap(),
-                &OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]),
+                &OwnedColumn::<Curve25519Scalar>::BigInt(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    vec![],
+                ),
             )],
             3,
             &(),

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -143,6 +143,7 @@ mod tests {
         },
     };
     use curve25519_dalek::RistrettoPoint;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_get_length_and_offset_of_tables() {
@@ -171,7 +172,7 @@ mod tests {
         let no_rows_commitment = TableCommitment::try_from_columns_with_offset(
             [(
                 &"column_c".parse().unwrap(),
-                &OwnedColumn::<Curve25519Scalar>::BigInt(vec![]),
+                &OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]),
             )],
             3,
             &(),
@@ -202,6 +203,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_commitment_of_a_column() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
@@ -227,7 +229,7 @@ mod tests {
             query_commitments.get_commitment(ColumnRef::new(
                 table_a_id,
                 column_a_id,
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             )),
             table_a_commitment.column_commitments().commitments()[0]
         );
@@ -235,7 +237,7 @@ mod tests {
             query_commitments.get_commitment(ColumnRef::new(
                 table_a_id,
                 column_b_id,
-                ColumnType::VarChar
+                ColumnType::VarChar(meta)
             )),
             table_a_commitment.column_commitments().commitments()[1]
         );
@@ -243,7 +245,7 @@ mod tests {
             query_commitments.get_commitment(ColumnRef::new(
                 table_b_id,
                 column_a_id,
-                ColumnType::Scalar
+                ColumnType::Scalar(meta)
             )),
             table_b_commitment.column_commitments().commitments()[0]
         );
@@ -252,6 +254,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_schema_of_tables() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();
 
@@ -286,19 +289,19 @@ mod tests {
             query_commitments
                 .lookup_column(table_a_id, column_a_id)
                 .unwrap(),
-            ColumnType::BigInt
+            ColumnType::BigInt(meta)
         );
         assert_eq!(
             query_commitments
                 .lookup_column(table_a_id, column_b_id)
                 .unwrap(),
-            ColumnType::VarChar
+            ColumnType::VarChar(meta)
         );
         assert_eq!(
             query_commitments.lookup_schema(table_a_id),
             vec![
-                (column_a_id, ColumnType::BigInt),
-                (column_b_id, ColumnType::VarChar)
+                (column_a_id, ColumnType::BigInt(meta)),
+                (column_b_id, ColumnType::VarChar(meta))
             ]
         );
 
@@ -306,7 +309,7 @@ mod tests {
             query_commitments
                 .lookup_column(table_b_id, column_a_id)
                 .unwrap(),
-            ColumnType::Scalar
+            ColumnType::Scalar(meta)
         );
         assert_eq!(
             query_commitments.lookup_column(table_b_id, column_b_id),
@@ -314,7 +317,7 @@ mod tests {
         );
         assert_eq!(
             query_commitments.lookup_schema(table_b_id),
-            vec![(column_a_id, ColumnType::Scalar),]
+            vec![(column_a_id, ColumnType::Scalar(meta)),]
         );
 
         assert_eq!(
@@ -327,6 +330,7 @@ mod tests {
     #[allow(clippy::similar_names)]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 3);
@@ -372,10 +376,10 @@ mod tests {
 
         let query_commitments = QueryCommitments::<DoryCommitment>::from_accessor_with_max_bounds(
             [
-                ColumnRef::new(table_a_id, column_a_id, ColumnType::BigInt),
-                ColumnRef::new(table_b_id, column_a_id, ColumnType::Scalar),
-                ColumnRef::new(table_a_id, column_b_id, ColumnType::VarChar),
-                ColumnRef::new(table_b_id, column_b_id, ColumnType::Int128),
+                ColumnRef::new(table_a_id, column_a_id, ColumnType::BigInt(meta)),
+                ColumnRef::new(table_b_id, column_a_id, ColumnType::Scalar(meta)),
+                ColumnRef::new(table_a_id, column_b_id, ColumnType::VarChar(meta)),
+                ColumnRef::new(table_b_id, column_b_id, ColumnType::Int128(meta)),
             ],
             &accessor,
         );

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -128,13 +128,12 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
             commitment::{Bounds, ColumnBounds},
             database::{
-                owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableTestAccessor,
-                TestAccessor,
+                owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+                OwnedTableTestAccessor, TestAccessor,
             },
             scalar::Curve25519Scalar,
         },

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -505,6 +505,7 @@ fn num_rows_of_columns<'a>(
 #[cfg(all(test, feature = "arrow", feature = "blitzar"))]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
             database::{owned_table_utility::*, OwnedColumn},
@@ -514,7 +515,6 @@ mod tests {
         record_batch,
     };
     use curve25519_dalek::RistrettoPoint;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
@@ -546,10 +546,10 @@ mod tests {
         assert_eq!(empty_table_commitment.num_rows(), 0);
 
         // no-rows case
-        empty_columns_iter.insert("column_a".parse().unwrap(), OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![]
-        ));
+        empty_columns_iter.insert(
+            "column_a".parse().unwrap(),
+            OwnedColumn::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]),
+        );
         let empty_table_commitment =
             TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
                 &empty_columns_iter,
@@ -600,7 +600,8 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
+        let empty_column =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -657,8 +658,14 @@ mod tests {
         let column_id_b = "column_b".parse().unwrap();
         let column_id_c = "column_c".parse().unwrap();
 
-        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1]);
-        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1, 2]);
+        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![1],
+        );
+        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![1, 2],
+        );
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -796,7 +803,10 @@ mod tests {
         let column_id_a = "column_a".parse().unwrap();
         let column_id_b = "column_b".parse().unwrap();
 
-        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1, 2, 3]);
+        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![1, 2, 3],
+        );
 
         let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [(&column_id_a, &column_data), (&column_id_b, &column_data)],
@@ -844,9 +854,14 @@ mod tests {
         .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
-        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![5, 6, 7]);
-        let column_b_append_data =
-            OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, ["amet", "consectetur"].map(String::from).to_vec());
+        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![5, 6, 7],
+        );
+        let column_b_append_data = OwnedColumn::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ["amet", "consectetur"].map(String::from).to_vec(),
+        );
 
         let append_result = table_commitment.try_append_rows(
             [
@@ -1280,11 +1295,17 @@ mod tests {
         let columns = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 2, 3]),
+                &Column::<Curve25519Scalar>::BigInt(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    &[1, 2, 3],
+                ),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&["1", "2", "3"], &b_scals)),
+                &Column::<Curve25519Scalar>::VarChar(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    (&["1", "2", "3"], &b_scals),
+                ),
             ),
         ];
 
@@ -1307,11 +1328,17 @@ mod tests {
         let columns2 = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[4, 5, 6]),
+                &Column::<Curve25519Scalar>::BigInt(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    &[4, 5, 6],
+                ),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&["4", "5", "6"], &b_scals2)),
+                &Column::<Curve25519Scalar>::VarChar(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    (&["4", "5", "6"], &b_scals2),
+                ),
             ),
         ];
 

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -514,6 +514,7 @@ mod tests {
         record_batch,
     };
     use curve25519_dalek::RistrettoPoint;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
@@ -545,7 +546,10 @@ mod tests {
         assert_eq!(empty_table_commitment.num_rows(), 0);
 
         // no-rows case
-        empty_columns_iter.insert("column_a".parse().unwrap(), OwnedColumn::BigInt(vec![]));
+        empty_columns_iter.insert("column_a".parse().unwrap(), OwnedColumn::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            vec![]
+        ));
         let empty_table_commitment =
             TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
                 &empty_columns_iter,
@@ -596,7 +600,7 @@ mod tests {
         let duplicate_identifier_b = "duplicate_identifier_b".parse().unwrap();
         let unique_identifier = "unique_identifier".parse().unwrap();
 
-        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![]);
+        let empty_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -653,8 +657,8 @@ mod tests {
         let column_id_b = "column_b".parse().unwrap();
         let column_id_c = "column_c".parse().unwrap();
 
-        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1]);
-        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1, 2]);
+        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1]);
+        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1, 2]);
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -792,7 +796,7 @@ mod tests {
         let column_id_a = "column_a".parse().unwrap();
         let column_id_b = "column_b".parse().unwrap();
 
-        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1, 2, 3]);
+        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![1, 2, 3]);
 
         let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [(&column_id_a, &column_data), (&column_id_b, &column_data)],
@@ -840,9 +844,9 @@ mod tests {
         .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
-        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(vec![5, 6, 7]);
+        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![5, 6, 7]);
         let column_b_append_data =
-            OwnedColumn::VarChar(["amet", "consectetur"].map(String::from).to_vec());
+            OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, ["amet", "consectetur"].map(String::from).to_vec());
 
         let append_result = table_commitment.try_append_rows(
             [
@@ -1276,11 +1280,11 @@ mod tests {
         let columns = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(&[1, 2, 3]),
+                &Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 2, 3]),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar((&["1", "2", "3"], &b_scals)),
+                &Column::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&["1", "2", "3"], &b_scals)),
             ),
         ];
 
@@ -1303,11 +1307,11 @@ mod tests {
         let columns2 = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(&[4, 5, 6]),
+                &Column::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[4, 5, 6]),
             ),
             (
                 &"b".parse().unwrap(),
-                &Column::<Curve25519Scalar>::VarChar((&["4", "5", "6"], &b_scals2)),
+                &Column::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&["4", "5", "6"], &b_scals2)),
             ),
         ];
 

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -505,10 +505,9 @@ fn num_rows_of_columns<'a>(
 #[cfg(all(test, feature = "arrow", feature = "blitzar"))]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
-            database::{owned_table_utility::*, OwnedColumn},
+            database::{owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn},
             map::IndexMap,
             scalar::Curve25519Scalar,
         },

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -507,7 +507,7 @@ mod tests {
     use super::*;
     use crate::{
         base::{
-            database::{owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn},
+            database::{owned_table_utility::*, ColumnNullability, OwnedColumn},
             map::IndexMap,
             scalar::Curve25519Scalar,
         },
@@ -547,7 +547,7 @@ mod tests {
         // no-rows case
         empty_columns_iter.insert(
             "column_a".parse().unwrap(),
-            OwnedColumn::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]),
+            OwnedColumn::BigInt(ColumnNullability::NotNullable, vec![]),
         );
         let empty_table_commitment =
             TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
@@ -600,7 +600,7 @@ mod tests {
         let unique_identifier = "unique_identifier".parse().unwrap();
 
         let empty_column =
-            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![]);
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![]);
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -657,14 +657,10 @@ mod tests {
         let column_id_b = "column_b".parse().unwrap();
         let column_id_c = "column_c".parse().unwrap();
 
-        let one_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![1],
-        );
-        let two_row_column = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![1, 2],
-        );
+        let one_row_column =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![1]);
+        let two_row_column =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![1, 2]);
 
         let from_columns_result = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [
@@ -802,10 +798,8 @@ mod tests {
         let column_id_a = "column_a".parse().unwrap();
         let column_id_b = "column_b".parse().unwrap();
 
-        let column_data = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![1, 2, 3],
-        );
+        let column_data =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![1, 2, 3]);
 
         let mut table_commitment = TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
             [(&column_id_a, &column_data), (&column_id_b, &column_data)],
@@ -853,12 +847,10 @@ mod tests {
         .unwrap();
         let column_commitments = table_commitment.column_commitments().clone();
 
-        let column_a_append_data = OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            vec![5, 6, 7],
-        );
+        let column_a_append_data =
+            OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, vec![5, 6, 7]);
         let column_b_append_data = OwnedColumn::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             ["amet", "consectetur"].map(String::from).to_vec(),
         );
 
@@ -1294,15 +1286,12 @@ mod tests {
         let columns = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    &[1, 2, 3],
-                ),
+                &Column::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, &[1, 2, 3]),
             ),
             (
                 &"b".parse().unwrap(),
                 &Column::<Curve25519Scalar>::VarChar(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     (&["1", "2", "3"], &b_scals),
                 ),
             ),
@@ -1327,15 +1316,12 @@ mod tests {
         let columns2 = [
             (
                 &"a".parse().unwrap(),
-                &Column::<Curve25519Scalar>::BigInt(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    &[4, 5, 6],
-                ),
+                &Column::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, &[4, 5, 6]),
             ),
             (
                 &"b".parse().unwrap(),
                 &Column::<Curve25519Scalar>::VarChar(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     (&["4", "5", "6"], &b_scals2),
                 ),
             ),

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -174,9 +174,8 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
-        database::{Column, OwnedColumn},
+        database::{Column, ColumnTypeAssociatedData, OwnedColumn},
         scalar::Curve25519Scalar,
     };
     use blitzar::{compute::compute_curve25519_commitments, sequence::Sequence};

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -180,9 +180,11 @@ mod tests {
     };
     use blitzar::{compute::compute_curve25519_commitments, sequence::Sequence};
     use curve25519_dalek::{ristretto::CompressedRistretto, RistrettoPoint};
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_convert_from_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // empty case
         let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(
             Vec::<Column<Curve25519Scalar>>::new(),
@@ -197,8 +199,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
         ];
 
         let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
@@ -226,19 +228,20 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
         ];
 
         commitments
@@ -269,12 +272,13 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
@@ -286,6 +290,7 @@ mod tests {
         ));
 
         let new_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(
+            meta,
             column_a[3..].to_vec(),
         )];
         assert!(matches!(
@@ -294,9 +299,9 @@ mod tests {
         ));
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
-            OwnedColumn::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
+            OwnedColumn::BigInt(meta, column_a[3..].to_vec()),
         ];
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &()),
@@ -306,21 +311,22 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56];
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
         let column_c = ["sit", "amet", "consectetur"].map(String::from);
         let column_d = [78i64, 90, 1112];
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
         ];
 
         let mut commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::VarChar(column_c.to_vec()),
-            OwnedColumn::BigInt(column_d.to_vec()),
+            OwnedColumn::<Curve25519Scalar>::VarChar(meta, column_c.to_vec()),
+            OwnedColumn::BigInt(meta, column_d.to_vec()),
         ];
 
         commitments.extend_columns_with_offset(&new_columns, 0, &());
@@ -356,19 +362,20 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments_a = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
         ];
 
         let commitments_b = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
@@ -398,12 +405,13 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
@@ -416,6 +424,7 @@ mod tests {
         ));
 
         let new_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(
+            meta,
             column_a[3..].to_vec(),
         )];
         let new_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
@@ -425,9 +434,9 @@ mod tests {
         ));
 
         let new_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
-            OwnedColumn::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
+            OwnedColumn::BigInt(meta, column_a[3..].to_vec()),
         ];
         let new_commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&new_columns, 3, &());
         assert!(matches!(
@@ -438,19 +447,20 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments_a = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
 
         let full_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
         ];
 
         let commitments_b = Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
@@ -476,12 +486,13 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(&columns, 0, &());
@@ -494,7 +505,7 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let full_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec())];
+        let full_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec())];
         let full_commitments =
             Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
         assert!(matches!(
@@ -503,9 +514,9 @@ mod tests {
         ));
 
         let full_columns = vec![
-            OwnedColumn::<Curve25519Scalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
-            OwnedColumn::BigInt(column_a.to_vec()),
+            OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
+            OwnedColumn::BigInt(meta, column_a.to_vec()),
         ];
         let full_commitments =
             Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -174,13 +174,13 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
 #[cfg(all(test, feature = "blitzar"))]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::{
         database::{Column, OwnedColumn},
         scalar::Curve25519Scalar,
     };
     use blitzar::{compute::compute_curve25519_commitments, sequence::Sequence};
     use curve25519_dalek::{ristretto::CompressedRistretto, RistrettoPoint};
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_convert_from_columns() {
@@ -505,7 +505,10 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let full_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(meta, column_a.to_vec())];
+        let full_columns = vec![OwnedColumn::<Curve25519Scalar>::BigInt(
+            meta,
+            column_a.to_vec(),
+        )];
         let full_commitments =
             Vec::<RistrettoPoint>::from_columns_with_offset(&full_columns, 0, &());
         assert!(matches!(

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -175,7 +175,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
 mod tests {
     use super::*;
     use crate::base::{
-        database::{Column, ColumnTypeAssociatedData, OwnedColumn},
+        database::{Column, ColumnNullability, OwnedColumn},
         scalar::Curve25519Scalar,
     };
     use blitzar::{compute::compute_curve25519_commitments, sequence::Sequence};
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn we_can_convert_from_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // empty case
         let commitments = Vec::<RistrettoPoint>::from_columns_with_offset(
             Vec::<Column<Curve25519Scalar>>::new(),
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56];
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
         let column_c = ["sit", "amet", "consectetur"].map(String::from);
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
@@ -485,7 +485,7 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -1,4 +1,5 @@
 use super::scalar_and_i256_conversions::convert_i256_to_scalar;
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{database::Column, math::decimal::Precision, scalar::Scalar};
 use arrow::{
     array::{
@@ -12,7 +13,6 @@ use bumpalo::Bump;
 use core::ops::Range;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
 use snafu::Snafu;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[derive(Snafu, Debug, PartialEq)]
 /// Errors caused by conversions between Arrow and owned types.
@@ -236,7 +236,10 @@ impl ArrayRefExt for ArrayRef {
             }
             DataType::Int8 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int8Array>() {
-                    Ok(Column::TinyInt(meta, &array.values()[range.start..range.end]))
+                    Ok(Column::TinyInt(
+                        meta,
+                        &array.values()[range.start..range.end],
+                    ))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -245,7 +248,10 @@ impl ArrayRefExt for ArrayRef {
             }
             DataType::Int16 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int16Array>() {
-                    Ok(Column::SmallInt(meta, &array.values()[range.start..range.end]))
+                    Ok(Column::SmallInt(
+                        meta,
+                        &array.values()[range.start..range.end],
+                    ))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -263,7 +269,10 @@ impl ArrayRefExt for ArrayRef {
             }
             DataType::Int64 => {
                 if let Some(array) = self.as_any().downcast_ref::<Int64Array>() {
-                    Ok(Column::BigInt(meta, &array.values()[range.start..range.end]))
+                    Ok(Column::BigInt(
+                        meta,
+                        &array.values()[range.start..range.end],
+                    ))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -272,7 +281,10 @@ impl ArrayRefExt for ArrayRef {
             }
             DataType::Decimal128(38, 0) => {
                 if let Some(array) = self.as_any().downcast_ref::<Decimal128Array>() {
-                    Ok(Column::Int128(meta, &array.values()[range.start..range.end]))
+                    Ok(Column::Int128(
+                        meta,
+                        &array.values()[range.start..range.end],
+                    ))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),
@@ -410,7 +422,12 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &data[1..3])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &data[1..3]
+            )
         );
     }
 
@@ -428,7 +445,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             result,
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &[]
+            )
         );
     }
 
@@ -444,7 +466,12 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &[]
+            )
         );
     }
 
@@ -502,7 +529,10 @@ mod tests {
 
         assert_eq!(
             result.unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (expected_vals.as_slice(), expected_scals.as_slice()))
+            Column::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                (expected_vals.as_slice(), expected_scals.as_slice())
+            )
         );
     }
 
@@ -511,7 +541,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(StringArray::from(vec!["hello", "world", "test"]));
         let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[])));
+        assert_eq!(
+            result.unwrap(),
+            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[]))
+        );
     }
 
     #[test]
@@ -539,7 +572,10 @@ mod tests {
 
         assert_eq!(
             result.unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (expected_vals.as_slice(), expected_scals))
+            Column::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                (expected_vals.as_slice(), expected_scals)
+            )
         );
     }
 
@@ -578,7 +614,12 @@ mod tests {
         ];
         assert_eq!(
             result.unwrap(),
-            Column::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, Precision::new(75).unwrap(), 0, expected_scalars.as_slice())
+            Column::Decimal75(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                Precision::new(75).unwrap(),
+                0,
+                expected_scalars.as_slice()
+            )
         );
     }
 
@@ -594,7 +635,12 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, Precision::new(75).unwrap(), 0, &[])
+            Column::Decimal75(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                Precision::new(75).unwrap(),
+                0,
+                &[]
+            )
         );
     }
 
@@ -641,7 +687,10 @@ mod tests {
         );
 
         let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -689,7 +738,10 @@ mod tests {
         );
 
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..3), None);
-        assert_eq!(result.unwrap(), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &data[1..3]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &data[1..3])
+        );
     }
 
     #[test]
@@ -701,7 +753,10 @@ mod tests {
             Some(true),
         ]));
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
-        assert_eq!(result.unwrap(), Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true])
+        );
     }
 
     #[test]
@@ -713,7 +768,10 @@ mod tests {
             Some(true),
         ]));
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -749,7 +807,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int8Array::from(vec![1, -3, 42]));
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
-        assert_eq!(result.unwrap(), Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42]));
+        assert_eq!(
+            result.unwrap(),
+            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+        );
     }
 
     #[test]
@@ -757,7 +818,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int16Array::from(vec![1, -3, 42]));
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
-        assert_eq!(result.unwrap(), Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42]));
+        assert_eq!(
+            result.unwrap(),
+            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+        );
     }
 
     #[test]
@@ -765,7 +829,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int8Array::from(vec![1, -3, 42]));
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result.unwrap(),
+            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -773,7 +840,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int16Array::from(vec![1, -3, 42]));
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result.unwrap(),
+            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -829,7 +899,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1, -3, 42]));
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
-        assert_eq!(result.unwrap(), Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+        );
     }
 
     #[test]
@@ -837,7 +910,10 @@ mod tests {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1, -3, 42]));
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
-        assert_eq!(result.unwrap(), Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result.unwrap(),
+            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -937,7 +1013,10 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(result, Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -947,7 +1026,10 @@ mod tests {
         let result = array
             .to_column::<Curve25519Scalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(result, Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -957,7 +1039,10 @@ mod tests {
         let result = array
             .to_column::<Curve25519Scalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(result, Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -967,7 +1052,10 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(result, Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -977,7 +1065,10 @@ mod tests {
         let result = array
             .to_column::<Curve25519Scalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(result, Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -995,7 +1086,10 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(0..0), None)
             .unwrap();
-        assert_eq!(result, Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[]));
+        assert_eq!(
+            result,
+            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+        );
     }
 
     #[test]
@@ -1081,7 +1175,10 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&data[..], &scals[..]))
+            Column::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                (&data[..], &scals[..])
+            )
         );
     }
 
@@ -1112,7 +1209,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             result,
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &data[..])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &data[..]
+            )
         );
     }
 
@@ -1182,7 +1284,12 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &data[1..3])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &data[1..3]
+            )
         );
     }
 
@@ -1198,7 +1305,10 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&data[1..3], &scals[1..3]))
+            Column::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                (&data[1..3], &scals[1..3])
+            )
         );
     }
 
@@ -1212,7 +1322,10 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), Some(&scals))
                 .unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&data[..], &scals[..]))
+            Column::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                (&data[..], &scals[..])
+            )
         );
     }
 
@@ -1224,7 +1337,10 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(0..0), None)
             .unwrap();
-        assert_eq!(result, Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[])));
+        assert_eq!(
+            result,
+            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[]))
+        );
     }
 
     #[test]
@@ -1240,7 +1356,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             result,
-            Column::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[])
+            Column::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::Utc,
+                &[]
+            )
         );
     }
 

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -1,6 +1,6 @@
 use super::scalar_and_i256_conversions::convert_i256_to_scalar;
 use crate::base::{
-    database::{Column, ColumnTypeAssociatedData},
+    database::{Column, ColumnNullability},
     math::decimal::Precision,
     scalar::Scalar,
 };
@@ -206,7 +206,7 @@ impl ArrayRefExt for ArrayRef {
         range: &Range<usize>,
         precomputed_scals: Option<&'a [S]>,
     ) -> Result<Column<'a, S>, ArrowArrayToColumnConversionError> {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Start by checking for nulls
         if self.null_count() != 0 {
             return Err(ArrowArrayToColumnConversionError::ArrayContainsNulls);
@@ -426,7 +426,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &data[1..3]
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(
             result,
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &[]
@@ -470,7 +470,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &[]
@@ -533,7 +533,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 (expected_vals.as_slice(), expected_scals.as_slice())
             )
         );
@@ -546,7 +546,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[]))
+            Column::VarChar(ColumnNullability::NotNullable, (&[], &[]))
         );
     }
 
@@ -576,7 +576,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 (expected_vals.as_slice(), expected_scals)
             )
         );
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 Precision::new(75).unwrap(),
                 0,
                 expected_scalars.as_slice()
@@ -639,7 +639,7 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Column::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 Precision::new(75).unwrap(),
                 0,
                 &[]
@@ -692,7 +692,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::Int128(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -743,7 +743,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &data[1..3])
+            Column::Int128(ColumnNullability::NotNullable, &data[1..3])
         );
     }
 
@@ -758,7 +758,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true])
+            Column::Boolean(ColumnNullability::NotNullable, &[false, true])
         );
     }
 
@@ -773,7 +773,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::Boolean(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -812,7 +812,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+            Column::TinyInt(ColumnNullability::NotNullable, &[-3, 42])
         );
     }
 
@@ -823,7 +823,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+            Column::SmallInt(ColumnNullability::NotNullable, &[-3, 42])
         );
     }
 
@@ -834,7 +834,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::TinyInt(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -845,7 +845,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::SmallInt(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -904,7 +904,7 @@ mod tests {
         let result = array.to_column::<DoryScalar>(&alloc, &(1..3), None);
         assert_eq!(
             result.unwrap(),
-            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[-3, 42])
+            Column::Int(ColumnNullability::NotNullable, &[-3, 42])
         );
     }
 
@@ -915,7 +915,7 @@ mod tests {
         let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..1), None);
         assert_eq!(
             result.unwrap(),
-            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::Int(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -1016,10 +1016,7 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(
-            result,
-            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
-        );
+        assert_eq!(result, Column::Boolean(ColumnNullability::NotNullable, &[]));
     }
 
     #[test]
@@ -1029,10 +1026,7 @@ mod tests {
         let result = array
             .to_column::<Curve25519Scalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(
-            result,
-            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
-        );
+        assert_eq!(result, Column::TinyInt(ColumnNullability::NotNullable, &[]));
     }
 
     #[test]
@@ -1044,7 +1038,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             result,
-            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
+            Column::SmallInt(ColumnNullability::NotNullable, &[])
         );
     }
 
@@ -1055,10 +1049,7 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(
-            result,
-            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
-        );
+        assert_eq!(result, Column::Int(ColumnNullability::NotNullable, &[]));
     }
 
     #[test]
@@ -1068,10 +1059,7 @@ mod tests {
         let result = array
             .to_column::<Curve25519Scalar>(&alloc, &(2..2), None)
             .unwrap();
-        assert_eq!(
-            result,
-            Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
-        );
+        assert_eq!(result, Column::BigInt(ColumnNullability::NotNullable, &[]));
     }
 
     #[test]
@@ -1089,10 +1077,7 @@ mod tests {
         let result = array
             .to_column::<DoryScalar>(&alloc, &(0..0), None)
             .unwrap();
-        assert_eq!(
-            result,
-            Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[])
-        );
+        assert_eq!(result, Column::Int128(ColumnNullability::NotNullable, &[]));
     }
 
     #[test]
@@ -1104,7 +1089,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(1..1), None)
                 .unwrap(),
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[]))
+            Column::VarChar(ColumnNullability::NotNullable, (&[], &[]))
         );
     }
 
@@ -1140,7 +1125,7 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, -3])
+            Column::TinyInt(ColumnNullability::NotNullable, &[1, -3])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int16Array::from(vec![1, -3]));
@@ -1148,7 +1133,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, -3])
+            Column::SmallInt(ColumnNullability::NotNullable, &[1, -3])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![1, -3]));
@@ -1156,7 +1141,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, -3])
+            Column::Int(ColumnNullability::NotNullable, &[1, -3])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int64Array::from(vec![1, -3]));
@@ -1164,7 +1149,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, -3])
+            Column::BigInt(ColumnNullability::NotNullable, &[1, -3])
         );
     }
 
@@ -1178,10 +1163,7 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                (&data[..], &scals[..])
-            )
+            Column::VarChar(ColumnNullability::NotNullable, (&data[..], &scals[..]))
         );
     }
 
@@ -1194,7 +1176,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), None)
                 .unwrap(),
-            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &data[..])
+            Column::Boolean(ColumnNullability::NotNullable, &data[..])
         );
     }
 
@@ -1213,7 +1195,7 @@ mod tests {
         assert_eq!(
             result,
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &data[..]
@@ -1230,7 +1212,7 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true])
+            Column::Boolean(ColumnNullability::NotNullable, &[false, true])
         );
     }
 
@@ -1244,7 +1226,7 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 127])
+            Column::TinyInt(ColumnNullability::NotNullable, &[1, 127])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int16Array::from(vec![0, 1, 545]));
@@ -1252,7 +1234,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 545])
+            Column::SmallInt(ColumnNullability::NotNullable, &[1, 545])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int32Array::from(vec![0, 1, 545]));
@@ -1260,7 +1242,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::Int(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 545])
+            Column::Int(ColumnNullability::NotNullable, &[1, 545])
         );
 
         let array: ArrayRef = Arc::new(arrow::array::Int64Array::from(vec![0, 1, 545]));
@@ -1268,7 +1250,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[1, 545])
+            Column::BigInt(ColumnNullability::NotNullable, &[1, 545])
         );
     }
 
@@ -1288,7 +1270,7 @@ mod tests {
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &data[1..3]
@@ -1308,10 +1290,7 @@ mod tests {
             array
                 .to_column::<DoryScalar>(&alloc, &(1..3), None)
                 .unwrap(),
-            Column::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                (&data[1..3], &scals[1..3])
-            )
+            Column::VarChar(ColumnNullability::NotNullable, (&data[1..3], &scals[1..3]))
         );
     }
 
@@ -1325,10 +1304,7 @@ mod tests {
             array
                 .to_column::<Curve25519Scalar>(&alloc, &(0..2), Some(&scals))
                 .unwrap(),
-            Column::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                (&data[..], &scals[..])
-            )
+            Column::VarChar(ColumnNullability::NotNullable, (&data[..], &scals[..]))
         );
     }
 
@@ -1342,7 +1318,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             result,
-            Column::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, (&[], &[]))
+            Column::VarChar(ColumnNullability::NotNullable, (&[], &[]))
         );
     }
 
@@ -1360,7 +1336,7 @@ mod tests {
         assert_eq!(
             result,
             Column::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 PoSQLTimeUnit::Second,
                 PoSQLTimeZone::Utc,
                 &[]

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -1,6 +1,9 @@
 use super::scalar_and_i256_conversions::convert_i256_to_scalar;
-use crate::base::database::ColumnTypeAssociatedData;
-use crate::base::{database::Column, math::decimal::Precision, scalar::Scalar};
+use crate::base::{
+    database::{Column, ColumnTypeAssociatedData},
+    math::decimal::Precision,
+    scalar::Scalar,
+};
 use arrow::{
     array::{
         Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -422,7 +422,10 @@ impl ColumnType {
         }
         self.to_integer_bits().and_then(|self_bits| {
             other.to_integer_bits().and_then(|other_bits| {
-                Self::from_integer_bits(self_bits.max(other_bits), self.is_nullable())
+                Self::from_integer_bits(
+                    self_bits.max(other_bits),
+                    self.is_nullable() || other.is_nullable(),
+                )
             })
         })
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -303,34 +303,38 @@ impl Display for ColumnTypeAssociatedData {
 pub enum ColumnType {
     /// Mapped to bool
     #[serde(alias = "BOOLEAN", alias = "boolean")]
-    Boolean(ColumnTypeAssociatedData),
+    Boolean(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i8
     #[serde(alias = "TINYINT", alias = "tinyint")]
-    TinyInt(ColumnTypeAssociatedData),
+    TinyInt(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i16
     #[serde(alias = "SMALLINT", alias = "smallint")]
-    SmallInt(ColumnTypeAssociatedData),
+    SmallInt(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i32
     #[serde(alias = "INT", alias = "int")]
-    Int(ColumnTypeAssociatedData),
+    Int(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i64
     #[serde(alias = "BIGINT", alias = "bigint")]
-    BigInt(ColumnTypeAssociatedData),
+    BigInt(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i128
     #[serde(rename = "Decimal", alias = "DECIMAL", alias = "decimal")]
-    Int128(ColumnTypeAssociatedData),
+    Int128(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to String
     #[serde(alias = "VARCHAR", alias = "varchar")]
-    VarChar(ColumnTypeAssociatedData),
+    VarChar(#[serde(default)] ColumnTypeAssociatedData),
     /// Mapped to i256
     #[serde(rename = "Decimal75", alias = "DECIMAL75", alias = "decimal75")]
-    Decimal75(ColumnTypeAssociatedData, Precision, i8),
+    Decimal75(#[serde(default)] ColumnTypeAssociatedData, Precision, i8),
     /// Mapped to i64
     #[serde(alias = "TIMESTAMP", alias = "timestamp")]
-    TimestampTZ(ColumnTypeAssociatedData, PoSQLTimeUnit, PoSQLTimeZone),
+    TimestampTZ(
+        #[serde(default)] ColumnTypeAssociatedData,
+        PoSQLTimeUnit,
+        PoSQLTimeZone,
+    ),
     /// Mapped to [`Curve25519Scalar`](crate::base::scalar::Curve25519Scalar)
     #[serde(alias = "SCALAR", alias = "scalar")]
-    Scalar(ColumnTypeAssociatedData),
+    Scalar(#[serde(default)] ColumnTypeAssociatedData),
 }
 
 impl ColumnType {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -229,6 +229,11 @@ impl<'a, S: Scalar> Column<'a, S> {
     }
 }
 
+#[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize, Copy, Default)]
+pub struct ColumnTypeAssociatedData {
+    nullable: bool
+}
+
 /// Represents the supported data types of a column in an in-memory,
 /// column-oriented database.
 ///

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -82,17 +82,17 @@ impl<'a, S: Scalar> Column<'a, S> {
     #[must_use]
     pub fn len(&self) -> usize {
         match self {
-            Self::Boolean(col) => col.len(),
-            Self::TinyInt(col) => col.len(),
-            Self::SmallInt(col) => col.len(),
-            Self::Int(col) => col.len(),
-            Self::BigInt(col) | Self::TimestampTZ(_, _, col) => col.len(),
-            Self::VarChar((col, scals)) => {
+            Self::Boolean(_, col) => col.len(),
+            Self::TinyInt(_, col) => col.len(),
+            Self::SmallInt(_, col) => col.len(),
+            Self::Int(_, col) => col.len(),
+            Self::BigInt(_, col) | Self::TimestampTZ(_, _, _, col) => col.len(),
+            Self::VarChar(_, (col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
-            Self::Int128(col) => col.len(),
-            Self::Scalar(col) | Self::Decimal75(_, _, col) => col.len(),
+            Self::Int128(_, col) => col.len(),
+            Self::Scalar(_, col) | Self::Decimal75(_, _, _, col) => col.len(),
         }
     }
     /// Returns `true` if the column has no elements.

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -271,7 +271,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     }
 }
 
-/// Represents the shared metadata for a column type
+/// Represents a columns nullability
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize, Copy)]
 pub enum ColumnNullability {
     Nullable,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -57,6 +57,25 @@ pub enum Column<'a, S: Scalar> {
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
+    fn get_metadata(&self) -> &ColumnTypeAssociatedData {
+        match self {
+            Self::Boolean(meta, _) => meta,
+            Self::TinyInt(meta, _) => meta,
+            Self::SmallInt(meta, _) => meta,
+            Self::Int(meta, _) => meta,
+            Self::BigInt(meta, _) => meta,
+            Self::VarChar(meta, _) => meta,
+            Self::Int128(meta, _) => meta,
+            Self::Scalar(meta, _) => meta,
+            Self::Decimal75(meta,  ..) => meta,
+            Self::TimestampTZ(meta, ..) => meta,
+        }
+    }
+
+    /// Can null be stored in this column
+    pub fn is_nullable(&self) -> bool {
+        self.get_metadata().nullable
+    }
     /// Provides the column type associated with the column
     #[must_use]
     pub fn column_type(&self) -> ColumnType {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -109,33 +109,33 @@ impl<'a, S: Scalar> Column<'a, S> {
     ) -> Self {
         match literal {
             LiteralValue::Boolean(value) => {
-                Column::Boolean(alloc.alloc_slice_fill_copy(length, *value))
+                Column::Boolean(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::TinyInt(value) => {
-                Column::TinyInt(alloc.alloc_slice_fill_copy(length, *value))
+                Column::TinyInt(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::SmallInt(value) => {
-                Column::SmallInt(alloc.alloc_slice_fill_copy(length, *value))
+                Column::SmallInt(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
-            LiteralValue::Int(value) => Column::Int(alloc.alloc_slice_fill_copy(length, *value)),
+            LiteralValue::Int(value) => Column::Int(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value)),
             LiteralValue::BigInt(value) => {
-                Column::BigInt(alloc.alloc_slice_fill_copy(length, *value))
+                Column::BigInt(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::Int128(value) => {
-                Column::Int128(alloc.alloc_slice_fill_copy(length, *value))
+                Column::Int128(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::Scalar(value) => {
-                Column::Scalar(alloc.alloc_slice_fill_copy(length, *value))
+                Column::Scalar(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_copy(length, *value))
             }
-            LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(
+            LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(ColumnTypeAssociatedData::default(),
                 *precision,
                 *scale,
                 alloc.alloc_slice_fill_copy(length, *value),
             ),
             LiteralValue::TimeStampTZ(tu, tz, value) => {
-                Column::TimestampTZ(*tu, *tz, alloc.alloc_slice_fill_copy(length, *value))
+                Column::TimestampTZ(ColumnTypeAssociatedData::default(), *tu, *tz, alloc.alloc_slice_fill_copy(length, *value))
             }
-            LiteralValue::VarChar((string, scalar)) => Column::VarChar((
+            LiteralValue::VarChar((string, scalar)) => Column::VarChar(ColumnTypeAssociatedData::default() ,(
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
                 alloc.alloc_slice_fill_copy(length, *scalar),
             )),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -771,125 +771,116 @@ mod tests {
 
     #[test]
     fn column_type_serializes_to_string() {
-        let column_type = ColumnType::TimestampTZ(
-            ColumnNullability::from_nullable(true),
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-        );
+        let column_type = ColumnTypeKind::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#"{"TimestampTZ":["Second","Utc"]}"#);
 
-        let column_type = ColumnType::TimestampTZ(
-            ColumnNullability::from_nullable(false),
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-        );
+        let column_type = ColumnTypeKind::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#"{"TimestampTZ":["Second","Utc"]} NOT NULL"#);
 
-        let null_meta = ColumnNullability::Nullable;
-        let column_type = ColumnType::Boolean(null_meta);
+        let column_type = ColumnTypeKind::Boolean;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Boolean""#);
 
-        let column_type = ColumnType::TinyInt(null_meta);
+        let column_type = ColumnTypeKind::TinyInt;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""TinyInt""#);
 
-        let column_type = ColumnType::SmallInt(null_meta);
+        let column_type = ColumnTypeKind::SmallInt;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""SmallInt""#);
 
-        let column_type = ColumnType::Int(null_meta);
+        let column_type = ColumnTypeKind::Int;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Int""#);
 
-        let column_type = ColumnType::BigInt(null_meta);
+        let column_type = ColumnTypeKind::BigInt;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""BigInt""#);
 
-        let column_type = ColumnType::Int128(null_meta);
+        let column_type = ColumnTypeKind::Int128;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Decimal""#);
 
-        let column_type = ColumnType::VarChar(null_meta);
+        let column_type = ColumnTypeKind::VarChar;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""VarChar""#);
 
-        let column_type = ColumnType::Scalar(null_meta);
+        let column_type = ColumnTypeKind::Scalar;
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Scalar""#);
 
-        let column_type = ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0);
+        let column_type = ColumnTypeKind::Decimal75(Precision::new(1).unwrap(), 0);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#"{"Decimal75":[1,0]}"#);
     }
 
     #[test]
     fn we_can_deserialize_columns_from_valid_strings() {
-        let null_meta = ColumnNullability::from_nullable(true);
         let expected_column_type =
-            ColumnType::TimestampTZ(null_meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
-        let deserialized: ColumnType =
+            ColumnTypeKind::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+        let deserialized: ColumnTypeKind =
             serde_json::from_str(r#"{"TimestampTZ":["Second","Utc"]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Boolean(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""Boolean""#).unwrap();
+        let expected_column_type = ColumnTypeKind::Boolean;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""Boolean""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::TinyInt(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""TinyInt""#).unwrap();
+        let expected_column_type = ColumnTypeKind::TinyInt;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""TinyInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::SmallInt(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""SmallInt""#).unwrap();
+        let expected_column_type = ColumnTypeKind::SmallInt;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""SmallInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""Int""#).unwrap();
+        let expected_column_type = ColumnTypeKind::Int;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""Int""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::BigInt(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""BigInt""#).unwrap();
+        let expected_column_type = ColumnTypeKind::BigInt;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""BigInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::TinyInt(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""TINYINT""#).unwrap();
+        let expected_column_type = ColumnTypeKind::TinyInt;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""TINYINT""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::SmallInt(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""SMALLINT""#).unwrap();
+        let expected_column_type = ColumnTypeKind::SmallInt;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""SMALLINT""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int128(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""DECIMAL""#).unwrap();
+        let expected_column_type = ColumnTypeKind::Int128;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""DECIMAL""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int128(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""Decimal""#).unwrap();
+        let expected_column_type = ColumnTypeKind::Int128;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""Decimal""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::VarChar(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""VarChar""#).unwrap();
+        let expected_column_type = ColumnTypeKind::VarChar;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""VarChar""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Scalar(null_meta);
-        let deserialized: ColumnType = serde_json::from_str(r#""SCALAR""#).unwrap();
+        let expected_column_type = ColumnTypeKind::Scalar;
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#""SCALAR""#).unwrap();
+        assert_eq!(deserialized, expected_column_type);
+
+        let expected_column_type = ColumnTypeKind::Decimal75(Precision::new(75).unwrap(), i8::MAX);
+        let deserialized: ColumnTypeKind =
+            serde_json::from_str(r#"{"Decimal75":[75, 127]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
         let expected_column_type =
-            ColumnType::Decimal75(null_meta, Precision::new(75).unwrap(), i8::MAX);
-        let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[75, 127]}"#).unwrap();
+            ColumnTypeKind::Decimal75(Precision::new(u8::MIN + 1).unwrap(), i8::MIN);
+        let deserialized: ColumnTypeKind =
+            serde_json::from_str(r#"{"Decimal75":[1, -128]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type =
-            ColumnType::Decimal75(null_meta, Precision::new(u8::MIN + 1).unwrap(), i8::MIN);
-        let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[1, -128]}"#).unwrap();
-        assert_eq!(deserialized, expected_column_type);
-
-        let expected_column_type = ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0);
-        let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[1, 0]}"#).unwrap();
+        let expected_column_type = ColumnTypeKind::Decimal75(Precision::new(1).unwrap(), 0);
+        let deserialized: ColumnTypeKind = serde_json::from_str(r#"{"Decimal75":[1, 0]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
     }
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -515,23 +515,23 @@ impl TryFrom<DataType> for ColumnType {
 impl Display for ColumnType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ColumnType::Boolean => write!(f, "BOOLEAN"),
-            ColumnType::TinyInt => write!(f, "TINYINT"),
-            ColumnType::SmallInt => write!(f, "SMALLINT"),
-            ColumnType::Int => write!(f, "INT"),
-            ColumnType::BigInt => write!(f, "BIGINT"),
-            ColumnType::Int128 => write!(f, "DECIMAL"),
-            ColumnType::Decimal75(precision, scale) => {
+            ColumnType::Boolean(meta) => write!(f, "BOOLEAN {meta}"),
+            ColumnType::TinyInt(meta) => write!(f, "TINYINT {meta}"),
+            ColumnType::SmallInt(meta) => write!(f, "SMALLINT {meta}"),
+            ColumnType::Int(meta) => write!(f, "INT {meta}"),
+            ColumnType::BigInt(meta) => write!(f, "BIGINT {meta}"),
+            ColumnType::Int128(meta) => write!(f, "DECIMAL {meta}"),
+            ColumnType::Decimal75(meta, precision, scale) => {
                 write!(
                     f,
-                    "DECIMAL75(PRECISION: {:?}, SCALE: {scale})",
+                    "DECIMAL75(PRECISION: {:?}, SCALE: {scale}) {meta}",
                     precision.value()
                 )
             }
-            ColumnType::VarChar => write!(f, "VARCHAR"),
-            ColumnType::Scalar => write!(f, "SCALAR"),
-            ColumnType::TimestampTZ(timeunit, timezone) => {
-                write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")
+            ColumnType::VarChar(meta) => write!(f, "VARCHAR {meta}"),
+            ColumnType::Scalar(meta) => write!(f, "SCALAR {meta}"),
+            ColumnType::TimestampTZ(meta, timeunit, timezone) => {
+                write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone}) {meta}")
             }
         }
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -233,7 +233,7 @@ impl<'a, S: Scalar> Column<'a, S> {
 /// Represents the shared metadata for a column type
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize, Copy, Default)]
 pub struct ColumnTypeAssociatedData {
-    nullable: bool
+    pub(crate) nullable: bool
 }
 impl  ColumnTypeAssociatedData {
     pub const NULLABLE: ColumnTypeAssociatedData = ColumnTypeAssociatedData { nullable: true };
@@ -374,7 +374,11 @@ impl ColumnType {
         self.to_integer_bits().and_then(|self_bits| {
             other
                 .to_integer_bits()
-                .and_then(|other_bits| Self::from_integer_bits(self_bits.max(other_bits), false))
+                .and_then(|other_bits|
+                    Self::from_integer_bits(
+                        self_bits.max(other_bits),
+                        self.is_nullable()
+                    ))
         })
     }
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -625,199 +625,211 @@ mod tests {
 
     #[test]
     fn column_type_serializes_to_string() {
-        let column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+        let column_type = ColumnType::TimestampTZ(ColumnTypeAssociatedData {
+            nullable: true,
+        }, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#"{"TimestampTZ":["Second","Utc"]}"#);
 
-        let column_type = ColumnType::Boolean;
+        let column_type = ColumnType::TimestampTZ(ColumnTypeAssociatedData {
+            nullable: false,
+        }, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+        let serialized = serde_json::to_string(&column_type).unwrap();
+        assert_eq!(serialized, r#"{"TimestampTZ":["Second","Utc"]} NOT NULL"#);
+
+        let null_meta = ColumnTypeAssociatedData { nullable: true };
+        let column_type = ColumnType::Boolean(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Boolean""#);
 
-        let column_type = ColumnType::TinyInt;
+        let column_type = ColumnType::TinyInt(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""TinyInt""#);
 
-        let column_type = ColumnType::SmallInt;
+        let column_type = ColumnType::SmallInt(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""SmallInt""#);
 
-        let column_type = ColumnType::Int;
+        let column_type = ColumnType::Int(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Int""#);
 
-        let column_type = ColumnType::BigInt;
+        let column_type = ColumnType::BigInt(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""BigInt""#);
 
-        let column_type = ColumnType::Int128;
+        let column_type = ColumnType::Int128(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Decimal""#);
 
-        let column_type = ColumnType::VarChar;
+        let column_type = ColumnType::VarChar(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""VarChar""#);
 
-        let column_type = ColumnType::Scalar;
+        let column_type = ColumnType::Scalar(null_meta);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#""Scalar""#);
 
-        let column_type = ColumnType::Decimal75(Precision::new(1).unwrap(), 0);
+        let column_type = ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0);
         let serialized = serde_json::to_string(&column_type).unwrap();
         assert_eq!(serialized, r#"{"Decimal75":[1,0]}"#);
     }
 
     #[test]
     fn we_can_deserialize_columns_from_valid_strings() {
+
+        let null_meta = ColumnTypeAssociatedData { nullable: true };
         let expected_column_type =
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+            ColumnType::TimestampTZ(null_meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
         let deserialized: ColumnType =
             serde_json::from_str(r#"{"TimestampTZ":["Second","Utc"]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Boolean;
+        let expected_column_type = ColumnType::Boolean(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""Boolean""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::TinyInt;
+        let expected_column_type = ColumnType::TinyInt(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""TinyInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::SmallInt;
+        let expected_column_type = ColumnType::SmallInt(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""SmallInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int;
+        let expected_column_type = ColumnType::Int(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""Int""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::BigInt;
+        let expected_column_type = ColumnType::BigInt(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""BigInt""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::TinyInt;
+        let expected_column_type = ColumnType::TinyInt(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""TINYINT""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::SmallInt;
+        let expected_column_type = ColumnType::SmallInt(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""SMALLINT""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int128;
+        let expected_column_type = ColumnType::Int128(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""DECIMAL""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Int128;
+        let expected_column_type = ColumnType::Int128(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""Decimal""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::VarChar;
+        let expected_column_type = ColumnType::VarChar(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""VarChar""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Scalar;
+        let expected_column_type = ColumnType::Scalar(null_meta);
         let deserialized: ColumnType = serde_json::from_str(r#""SCALAR""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), i8::MAX);
+        let expected_column_type = ColumnType::Decimal75(null_meta, Precision::new(75).unwrap(), i8::MAX);
         let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[75, 127]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
         let expected_column_type =
-            ColumnType::Decimal75(Precision::new(u8::MIN + 1).unwrap(), i8::MIN);
+            ColumnType::Decimal75(null_meta, Precision::new(u8::MIN + 1).unwrap(), i8::MIN);
         let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[1, -128]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
-        let expected_column_type = ColumnType::Decimal75(Precision::new(1).unwrap(), 0);
+        let expected_column_type = ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0);
         let deserialized: ColumnType = serde_json::from_str(r#"{"Decimal75":[1, 0]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
     }
 
     #[test]
     fn we_can_deserialize_columns_from_lowercase_or_uppercase_strings() {
+        let null_meta = ColumnTypeAssociatedData { nullable: true };
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""boolean""#).unwrap(),
-            ColumnType::Boolean
+            ColumnType::Boolean(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""BOOLEAN""#).unwrap(),
-            ColumnType::Boolean
+            ColumnType::Boolean(null_meta)
         );
 
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""bigint""#).unwrap(),
-            ColumnType::BigInt
+            ColumnType::BigInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""BIGINT""#).unwrap(),
-            ColumnType::BigInt
+            ColumnType::BigInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""TINYINT""#).unwrap(),
-            ColumnType::TinyInt
+            ColumnType::TinyInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""tinyint""#).unwrap(),
-            ColumnType::TinyInt
+            ColumnType::TinyInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""SMALLINT""#).unwrap(),
-            ColumnType::SmallInt
+            ColumnType::SmallInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""smallint""#).unwrap(),
-            ColumnType::SmallInt
+            ColumnType::SmallInt(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""int""#).unwrap(),
-            ColumnType::Int
+            ColumnType::Int(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""INT""#).unwrap(),
-            ColumnType::Int
+            ColumnType::Int(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""decimal""#).unwrap(),
-            ColumnType::Int128
+            ColumnType::Int128(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""DECIMAL""#).unwrap(),
-            ColumnType::Int128
+            ColumnType::Int128(null_meta)
         );
 
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""VARCHAR""#).unwrap(),
-            ColumnType::VarChar
+            ColumnType::VarChar(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""varchar""#).unwrap(),
-            ColumnType::VarChar
+            ColumnType::VarChar(null_meta)
         );
 
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""SCALAR""#).unwrap(),
-            ColumnType::Scalar
+            ColumnType::Scalar(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#""scalar""#).unwrap(),
-            ColumnType::Scalar
+            ColumnType::Scalar(null_meta)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#"{"decimal75":[1,0]}"#).unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), 0)
+            ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0)
         );
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#"{"DECIMAL75":[1,0]}"#).unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), 0)
+            ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), 0)
         );
 
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#"{"decimal75":[10,5]}"#).unwrap(),
-            ColumnType::Decimal75(Precision::new(10).unwrap(), 5)
+            ColumnType::Decimal75(null_meta, Precision::new(10).unwrap(), 5)
         );
 
         assert_eq!(
             serde_json::from_str::<ColumnType>(r#"{"DECIMAL75":[1,-128]}"#).unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), -128)
+            ColumnType::Decimal75(null_meta, Precision::new(1).unwrap(), -128)
         );
     }
 
@@ -857,7 +869,8 @@ mod tests {
 
     #[test]
     fn we_can_convert_columntype_to_json_string_and_back() {
-        let boolean = ColumnType::Boolean;
+        let null_meta = ColumnTypeAssociatedData { nullable: true };
+        let boolean = ColumnType::Boolean(null_meta);
         let boolean_json = serde_json::to_string(&boolean).unwrap();
         assert_eq!(boolean_json, "\"Boolean\"");
         assert_eq!(
@@ -865,7 +878,7 @@ mod tests {
             boolean
         );
 
-        let tinyint = ColumnType::TinyInt;
+        let tinyint = ColumnType::TinyInt(null_meta);
         let tinyint_json = serde_json::to_string(&tinyint).unwrap();
         assert_eq!(tinyint_json, "\"TinyInt\"");
         assert_eq!(
@@ -873,7 +886,7 @@ mod tests {
             tinyint
         );
 
-        let smallint = ColumnType::SmallInt;
+        let smallint = ColumnType::SmallInt(null_meta);
         let smallint_json = serde_json::to_string(&smallint).unwrap();
         assert_eq!(smallint_json, "\"SmallInt\"");
         assert_eq!(
@@ -881,12 +894,12 @@ mod tests {
             smallint
         );
 
-        let int = ColumnType::Int;
+        let int = ColumnType::Int(null_meta);
         let int_json = serde_json::to_string(&int).unwrap();
         assert_eq!(int_json, "\"Int\"");
         assert_eq!(serde_json::from_str::<ColumnType>(&int_json).unwrap(), int);
 
-        let bigint = ColumnType::BigInt;
+        let bigint = ColumnType::BigInt(null_meta);
         let bigint_json = serde_json::to_string(&bigint).unwrap();
         assert_eq!(bigint_json, "\"BigInt\"");
         assert_eq!(
@@ -894,7 +907,7 @@ mod tests {
             bigint
         );
 
-        let int128 = ColumnType::Int128;
+        let int128 = ColumnType::Int128(null_meta);
         let int128_json = serde_json::to_string(&int128).unwrap();
         assert_eq!(int128_json, "\"Decimal\"");
         assert_eq!(
@@ -902,7 +915,7 @@ mod tests {
             int128
         );
 
-        let varchar = ColumnType::VarChar;
+        let varchar = ColumnType::VarChar(null_meta);
         let varchar_json = serde_json::to_string(&varchar).unwrap();
         assert_eq!(varchar_json, "\"VarChar\"");
         assert_eq!(
@@ -910,7 +923,7 @@ mod tests {
             varchar
         );
 
-        let scalar = ColumnType::Scalar;
+        let scalar = ColumnType::Scalar(null_meta);
         let scalar_json = serde_json::to_string(&scalar).unwrap();
         assert_eq!(scalar_json, "\"Scalar\"");
         assert_eq!(
@@ -918,7 +931,7 @@ mod tests {
             scalar
         );
 
-        let decimal75 = ColumnType::Decimal75(Precision::new(75).unwrap(), 0);
+        let decimal75 = ColumnType::Decimal75(null_meta, Precision::new(75).unwrap(), 0);
         let decimal75_json = serde_json::to_string(&decimal75).unwrap();
         assert_eq!(decimal75_json, r#"{"Decimal75":[75,0]}"#);
         assert_eq!(
@@ -929,6 +942,7 @@ mod tests {
 
     #[test]
     fn we_can_get_the_len_of_a_column() {
+        let null_meta = ColumnTypeAssociatedData { nullable: true };
         let precision = 10;
         let scale = 2;
 
@@ -939,35 +953,35 @@ mod tests {
         ];
 
         // Test non-empty columns
-        let column = Column::<DoryScalar>::Boolean(&[true, false, true]);
+        let column = Column::<DoryScalar>::Boolean(null_meta, &[true, false, true]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<DoryScalar>::TinyInt(&[1, 2, 3]);
+        let column = Column::<DoryScalar>::TinyInt(null_meta, &[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[1, 2, 3]);
+        let column = Column::<Curve25519Scalar>::SmallInt(null_meta, &[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int(&[1, 2, 3]);
+        let column = Column::<Curve25519Scalar>::Int(null_meta, &[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[1, 2, 3]);
+        let column = Column::<Curve25519Scalar>::BigInt(null_meta, &[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::VarChar((&["a", "b", "c"], &scalar_values));
+        let column = Column::VarChar(null_meta, (&["a", "b", "c"], &scalar_values));
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::<DoryScalar>::Int128(&[1, 2, 3]);
+        let column = Column::<DoryScalar>::Int128(null_meta, &[1, 2, 3]);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
-        let column = Column::Scalar(&scalar_values);
+        let column = Column::Scalar(null_meta, &scalar_values);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
@@ -978,63 +992,64 @@ mod tests {
         ];
 
         let precision = Precision::new(precision).unwrap();
-        let column = Column::Decimal75(precision, scale, &decimal_data);
+        let column = Column::Decimal75(null_meta, precision, scale, &decimal_data);
         assert_eq!(column.len(), 3);
         assert!(!column.is_empty());
 
         // Test empty columns
-        let column = Column::<DoryScalar>::Boolean(&[]);
+        let column = Column::<DoryScalar>::Boolean(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<DoryScalar>::TinyInt(&[]);
+        let column = Column::<DoryScalar>::TinyInt(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[]);
+        let column = Column::<Curve25519Scalar>::SmallInt(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int(&[]);
+        let column = Column::<Curve25519Scalar>::Int(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[]);
+        let column = Column::<Curve25519Scalar>::BigInt(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<DoryScalar>::VarChar((&[], &[]));
+        let column = Column::<DoryScalar>::VarChar(null_meta, (&[], &[]));
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<Curve25519Scalar>::Int128(&[]);
+        let column = Column::<Curve25519Scalar>::Int128(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column = Column::<DoryScalar>::Scalar(&[]);
+        let column = Column::<DoryScalar>::Scalar(null_meta, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
 
-        let column: Column<'_, Curve25519Scalar> = Column::Decimal75(precision, scale, &[]);
+        let column: Column<'_, Curve25519Scalar> = Column::Decimal75(null_meta, precision, scale, &[]);
         assert_eq!(column.len(), 0);
         assert!(column.is_empty());
     }
 
     #[test]
     fn we_can_convert_owned_columns_to_columns_round_trip() {
+        let meta = ColumnTypeAssociatedData::default();
         let alloc = Bump::new();
         // Integers
-        let owned_col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(vec![1, 2, 3, 4, 5]);
+        let owned_col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(meta, vec![1, 2, 3, 4, 5]);
         let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
-        assert_eq!(col, Column::Int128(&[1, 2, 3, 4, 5]));
+        assert_eq!(col, Column::Int128(meta, &[1, 2, 3, 4, 5]));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
 
         // Booleans
         let owned_col: OwnedColumn<Curve25519Scalar> =
-            OwnedColumn::Boolean(vec![true, false, true, false, true]);
+            OwnedColumn::Boolean(meta, vec![true, false, true, false, true]);
         let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
-        assert_eq!(col, Column::Boolean(&[true, false, true, false, true]));
+        assert_eq!(col, Column::Boolean(meta, &[true, false, true, false, true]));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
 
@@ -1048,12 +1063,13 @@ mod tests {
         ];
         let scalars = strs.iter().map(Curve25519Scalar::from).collect::<Vec<_>>();
         let owned_col = OwnedColumn::VarChar(
+            meta,
             strs.iter()
                 .map(ToString::to_string)
                 .collect::<Vec<String>>(),
         );
         let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
-        assert_eq!(col, Column::VarChar((&strs, &scalars)));
+        assert_eq!(col, Column::VarChar(meta, (&strs, &scalars)));
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
 
@@ -1061,11 +1077,11 @@ mod tests {
         let scalars: Vec<Curve25519Scalar> =
             [1, 2, 3, 4, 5].iter().map(Curve25519Scalar::from).collect();
         let owned_col: OwnedColumn<Curve25519Scalar> =
-            OwnedColumn::Decimal75(Precision::new(75).unwrap(), 127, scalars.clone());
+            OwnedColumn::Decimal75(meta, Precision::new(75).unwrap(), 127, scalars.clone());
         let col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(
             col,
-            Column::Decimal75(Precision::new(75).unwrap(), 127, &scalars)
+            Column::Decimal75(meta, Precision::new(75).unwrap(), 127, &scalars)
         );
         let new_owned_col = (&col).into();
         assert_eq!(owned_col, new_owned_col);
@@ -1073,27 +1089,28 @@ mod tests {
 
     #[test]
     fn we_can_get_the_data_size_of_a_column() {
-        let column = Column::<DoryScalar>::Boolean(&[true, false, true]);
+        let meta = ColumnTypeAssociatedData::default();
+        let column = Column::<DoryScalar>::Boolean(meta, &[true, false, true]);
         assert_eq!(column.column_type().byte_size(), 1);
         assert_eq!(column.column_type().bit_size(), 8);
 
-        let column = Column::<Curve25519Scalar>::TinyInt(&[1, 2, 3, 4]);
+        let column = Column::<Curve25519Scalar>::TinyInt(meta, &[1, 2, 3, 4]);
         assert_eq!(column.column_type().byte_size(), 1);
         assert_eq!(column.column_type().bit_size(), 8);
 
-        let column = Column::<Curve25519Scalar>::SmallInt(&[1, 2, 3, 4]);
+        let column = Column::<Curve25519Scalar>::SmallInt(meta, &[1, 2, 3, 4]);
         assert_eq!(column.column_type().byte_size(), 2);
         assert_eq!(column.column_type().bit_size(), 16);
 
-        let column = Column::<Curve25519Scalar>::Int(&[1, 2, 3]);
+        let column = Column::<Curve25519Scalar>::Int(meta, &[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 4);
         assert_eq!(column.column_type().bit_size(), 32);
 
-        let column = Column::<Curve25519Scalar>::BigInt(&[1]);
+        let column = Column::<Curve25519Scalar>::BigInt(meta, &[1]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
 
-        let column = Column::<DoryScalar>::Int128(&[1, 2]);
+        let column = Column::<DoryScalar>::Int128(meta, &[1, 2]);
         assert_eq!(column.column_type().byte_size(), 16);
         assert_eq!(column.column_type().bit_size(), 128);
 
@@ -1103,11 +1120,11 @@ mod tests {
             Curve25519Scalar::from(3),
         ];
 
-        let column = Column::VarChar((&["a", "b", "c", "d", "e"], &scalar_values));
+        let column = Column::VarChar(meta, (&["a", "b", "c", "d", "e"], &scalar_values));
         assert_eq!(column.column_type().byte_size(), 32);
         assert_eq!(column.column_type().bit_size(), 256);
 
-        let column = Column::Scalar(&scalar_values);
+        let column = Column::Scalar(meta, &scalar_values);
         assert_eq!(column.column_type().byte_size(), 32);
         assert_eq!(column.column_type().bit_size(), 256);
 
@@ -1120,12 +1137,12 @@ mod tests {
         ];
 
         let precision = Precision::new(precision).unwrap();
-        let column = Column::Decimal75(precision, scale, &decimal_data);
+        let column = Column::Decimal75(meta, precision, scale, &decimal_data);
         assert_eq!(column.column_type().byte_size(), 32);
         assert_eq!(column.column_type().bit_size(), 256);
 
         let column: Column<'_, DoryScalar> =
-            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]);
+            Column::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -286,9 +286,9 @@ impl Default for ColumnNullability {
 impl ColumnNullability {
     pub fn from_nullable(nullable: bool) -> Self {
         if nullable {
-            Self::NotNullable
-        } else {
             Self::Nullable
+        } else {
+            Self::NotNullable
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -48,7 +48,7 @@ pub enum Column<'a, S: Scalar> {
     /// String columns
     ///  - the first element maps to the str values.
     ///  - the second element maps to the str hashes (see [`crate::base::scalar::Scalar`]).
-    VarChar(ColumnTypeAssociatedData, &'a [&'a str], &'a [S]),
+    VarChar(ColumnTypeAssociatedData, (&'a [&'a str], &'a [S])),
     /// Timestamp columns with timezone
     /// - the first element maps to the stored `TimeUnit`
     /// - the second element maps to a timezone
@@ -66,7 +66,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::SmallInt(meta, _) => ColumnType::SmallInt(*meta),
             Self::Int(meta, _) => ColumnType::Int(*meta),
             Self::BigInt(meta, _) => ColumnType::BigInt(*meta),
-            Self::VarChar(meta, _, _) => ColumnType::VarChar(*meta),
+            Self::VarChar(meta, _) => ColumnType::VarChar(*meta),
             Self::Int128(meta, _) => ColumnType::Int128(*meta),
             Self::Scalar(meta, _) => ColumnType::Scalar(*meta),
             Self::Decimal75(meta, precision, scale, _) =>

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -145,35 +145,35 @@ impl<'a, S: Scalar> Column<'a, S> {
     /// Convert an `OwnedColumn` to a `Column`
     pub fn from_owned_column(owned_column: &'a OwnedColumn<S>, alloc: &'a Bump) -> Self {
         match owned_column {
-            OwnedColumn::Boolean(col) => Column::Boolean(col.as_slice()),
-            OwnedColumn::TinyInt(col) => Column::TinyInt(col.as_slice()),
-            OwnedColumn::SmallInt(col) => Column::SmallInt(col.as_slice()),
-            OwnedColumn::Int(col) => Column::Int(col.as_slice()),
-            OwnedColumn::BigInt(col) => Column::BigInt(col.as_slice()),
-            OwnedColumn::Int128(col) => Column::Int128(col.as_slice()),
-            OwnedColumn::Decimal75(precision, scale, col) => {
-                Column::Decimal75(*precision, *scale, col.as_slice())
+            OwnedColumn::Boolean(meta, col) => Column::Boolean(*meta, col.as_slice()),
+            OwnedColumn::TinyInt(meta, col) => Column::TinyInt(*meta, col.as_slice()),
+            OwnedColumn::SmallInt(meta, col) => Column::SmallInt(*meta, col.as_slice()),
+            OwnedColumn::Int(meta, col) => Column::Int(*meta, col.as_slice()),
+            OwnedColumn::BigInt(meta, col) => Column::BigInt(*meta, col.as_slice()),
+            OwnedColumn::Int128(meta, col) => Column::Int128(*meta, col.as_slice()),
+            OwnedColumn::Decimal75(meta, precision, scale, col) => {
+                Column::Decimal75(*meta, *precision, *scale, col.as_slice())
             }
-            OwnedColumn::Scalar(col) => Column::Scalar(col.as_slice()),
-            OwnedColumn::VarChar(col) => {
+            OwnedColumn::Scalar(meta, col) => Column::Scalar(*meta, col.as_slice()),
+            OwnedColumn::VarChar(meta, col) => {
                 let scalars = col.iter().map(S::from).collect::<Vec<_>>();
                 let strs = col
                     .iter()
                     .map(|s| s.as_str() as &'a str)
                     .collect::<Vec<_>>();
-                Column::VarChar((
+                Column::VarChar(*meta, (
                     alloc.alloc_slice_clone(strs.as_slice()),
                     alloc.alloc_slice_copy(scalars.as_slice()),
                 ))
             }
-            OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col.as_slice()),
+            OwnedColumn::TimestampTZ(meta, tu, tz, col) => Column::TimestampTZ(*meta, *tu, *tz, col.as_slice()),
         }
     }
 
     /// Returns the column as a slice of booleans if it is a boolean column. Otherwise, returns None.
     pub(crate) fn as_boolean(&self) -> Option<&'a [bool]> {
         match self {
-            Self::Boolean(col) => Some(col),
+            Self::Boolean(_, col) => Some(col),
             _ => None,
         }
     }

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -145,7 +145,7 @@ pub fn try_divide_column_types(
         left_type: lhs,
         right_type: rhs,
     });
-    return match (lhs, rhs) {
+    match (lhs, rhs) {
         (lhs, rhs) if !lhs.is_numeric() || !rhs.is_numeric() => bin_err,
         (ColumnType::Scalar(_), _) | (_, ColumnType::Scalar(_)) => bin_err,
         (lhs, rhs) if lhs.is_integer() && rhs.is_integer() =>

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -176,7 +176,9 @@ pub fn try_divide_column_types(
                         },
                     })
                 })?;
-            Ok(ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, precision, scale))
+            Ok(ColumnType::Decimal75(ColumnTypeAssociatedData {
+                nullable: lhs.is_nullable() || rhs.is_nullable(),
+            }, precision, scale))
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -942,19 +942,55 @@ mod test {
     use super::*;
     use crate::base::scalar::Curve25519Scalar;
 
+    macro_rules! test_nullability {
+        ($cty:ident, $func:expr, $args:expr) => {
+            let lhs = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            let rhs = ColumnType::$cty(ColumnTypeAssociatedData::NOT_NULLABLE);
+            let actual = $func(lhs, rhs, $args).unwrap();
+            let expected = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            assert_eq!(expected, actual);
+
+            let lhs = ColumnType::$cty(ColumnTypeAssociatedData::NOT_NULLABLE);
+            let rhs = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            let actual = $func(lhs, rhs, $args).unwrap();
+            let expected = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            assert_eq!(expected, actual);
+        };
+        ($cty:ident, $func:expr) => {
+            let lhs = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            let rhs = ColumnType::$cty(ColumnTypeAssociatedData::NOT_NULLABLE);
+            let actual = $func(lhs, rhs).unwrap();
+            let expected = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            assert_eq!(expected, actual);
+
+            let lhs = ColumnType::$cty(ColumnTypeAssociatedData::NOT_NULLABLE);
+            let rhs = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            let actual = $func(lhs, rhs).unwrap();
+            let expected = ColumnType::$cty(ColumnTypeAssociatedData::NULLABLE);
+            assert_eq!(expected, actual);
+        };
+    }
+
     #[test]
     fn we_can_add_null_numeric_types() {
-        let lhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
-        let rhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
-        let expected = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
-        assert_eq!(expected, actual);
-
-        let lhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE);
-        let rhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
-        let expected = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
-        assert_eq!(expected, actual);
+        test_nullability!(TinyInt, try_add_subtract_column_types, BinaryOperator::Add);
+        test_nullability!(Int, try_add_subtract_column_types, BinaryOperator::Add);
+        test_nullability!(BigInt, try_add_subtract_column_types, BinaryOperator::Add);
+        test_nullability!(Int128, try_add_subtract_column_types, BinaryOperator::Add);
+    }
+    #[test]
+    fn we_can_mul_null_numeric_types() {
+        test_nullability!(TinyInt, try_multiply_column_types);
+        test_nullability!(Int, try_multiply_column_types);
+        test_nullability!(BigInt, try_multiply_column_types);
+        test_nullability!(Int128, try_multiply_column_types);
+    }
+    #[test]
+    fn we_can_divide_null_numeric_types() {
+        test_nullability!(TinyInt, try_divide_column_types);
+        test_nullability!(Int, try_divide_column_types);
+        test_nullability!(BigInt, try_divide_column_types);
+        test_nullability!(Int128, try_divide_column_types);
     }
     #[test]
     fn we_can_add_numeric_types() {

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -935,6 +935,21 @@ mod test {
     use crate::base::scalar::Curve25519Scalar;
 
     #[test]
+    fn we_can_add_null_numeric_types() {
+        let lhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
+        let rhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE);
+        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let expected = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
+        assert_eq!(expected, actual);
+
+        let lhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE);
+        let rhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
+        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let expected = ColumnType::TinyInt(ColumnTypeAssociatedData::NULLABLE);
+        assert_eq!(expected, actual);
+
+    }
+    #[test]
     fn we_can_add_numeric_types() {
         // lhs and rhs are integers with the same precision
         let lhs = ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE);

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -40,16 +40,33 @@ impl<S: Scalar> OwnedTable<S> {
     fn evaluate_literal(&self, lit: &Literal) -> ExpressionEvaluationResult<OwnedColumn<S>> {
         let len = self.num_rows();
         match lit {
-            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*b; len])),
-            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*i; len])),
-            Literal::Int128(i) => Ok(OwnedColumn::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*i; len])),
+            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                vec![*b; len],
+            )),
+            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                vec![*i; len],
+            )),
+            Literal::Int128(i) => Ok(OwnedColumn::Int128(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                vec![*i; len],
+            )),
             Literal::Decimal(d) => {
                 let scale = d.scale();
                 let precision = Precision::new(d.precision())?;
                 let scalar = try_into_to_scalar(d, precision, scale)?;
-                Ok(OwnedColumn::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, precision, scale, vec![scalar; len]))
+                Ok(OwnedColumn::Decimal75(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    precision,
+                    scale,
+                    vec![scalar; len],
+                ))
             }
-            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, vec![s.clone(); len])),
+            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                vec![s.clone(); len],
+            )),
             Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
                 ColumnTypeAssociatedData::NOT_NULLABLE,
                 its.timeunit(),

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -1,4 +1,4 @@
-use super::{ColumnTypeAssociatedData, ExpressionEvaluationError, ExpressionEvaluationResult};
+use super::{ColumnNullability, ExpressionEvaluationError, ExpressionEvaluationResult};
 use crate::base::{
     database::{OwnedColumn, OwnedTable},
     math::decimal::{try_into_to_scalar, Precision},
@@ -41,15 +41,15 @@ impl<S: Scalar> OwnedTable<S> {
         let len = self.num_rows();
         match lit {
             Literal::Boolean(b) => Ok(OwnedColumn::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 vec![*b; len],
             )),
             Literal::BigInt(i) => Ok(OwnedColumn::BigInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 vec![*i; len],
             )),
             Literal::Int128(i) => Ok(OwnedColumn::Int128(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 vec![*i; len],
             )),
             Literal::Decimal(d) => {
@@ -57,18 +57,18 @@ impl<S: Scalar> OwnedTable<S> {
                 let precision = Precision::new(d.precision())?;
                 let scalar = try_into_to_scalar(d, precision, scale)?;
                 Ok(OwnedColumn::Decimal75(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     precision,
                     scale,
                     vec![scalar; len],
                 ))
             }
             Literal::VarChar(s) => Ok(OwnedColumn::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 vec![s.clone(); len],
             )),
             Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 its.timeunit(),
                 its.timezone(),
                 vec![its.timestamp().timestamp(); len],

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -1,4 +1,4 @@
-use super::{ExpressionEvaluationError, ExpressionEvaluationResult};
+use super::{ColumnTypeAssociatedData, ExpressionEvaluationError, ExpressionEvaluationResult};
 use crate::base::{
     database::{OwnedColumn, OwnedTable},
     math::decimal::{try_into_to_scalar, Precision},
@@ -40,17 +40,18 @@ impl<S: Scalar> OwnedTable<S> {
     fn evaluate_literal(&self, lit: &Literal) -> ExpressionEvaluationResult<OwnedColumn<S>> {
         let len = self.num_rows();
         match lit {
-            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(vec![*b; len])),
-            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(vec![*i; len])),
-            Literal::Int128(i) => Ok(OwnedColumn::Int128(vec![*i; len])),
+            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*b; len])),
+            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*i; len])),
+            Literal::Int128(i) => Ok(OwnedColumn::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, vec![*i; len])),
             Literal::Decimal(d) => {
                 let scale = d.scale();
                 let precision = Precision::new(d.precision())?;
                 let scalar = try_into_to_scalar(d, precision, scale)?;
-                Ok(OwnedColumn::Decimal75(precision, scale, vec![scalar; len]))
+                Ok(OwnedColumn::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, precision, scale, vec![scalar; len]))
             }
-            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
+            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, vec![s.clone(); len])),
             Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
                 its.timeunit(),
                 its.timezone(),
                 vec![its.timestamp().timestamp(); len],

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -1,7 +1,7 @@
 use crate::base::{
     database::{
-        owned_table_utility::*, ColumnOperationError, ColumnTypeAssociatedData,
-        ExpressionEvaluationError, OwnedColumn, OwnedTable,
+        owned_table_utility::*, ColumnNullability, ColumnOperationError, ExpressionEvaluationError,
+        OwnedColumn, OwnedTable,
     },
     math::decimal::Precision,
     scalar::Curve25519Scalar,
@@ -15,7 +15,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_evaluate_a_simple_literal() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table: OwnedTable<Curve25519Scalar> =
         owned_table([varchar("languages", ["en", "es", "pt", "fr", "ht"])]);
 
@@ -65,7 +65,7 @@ fn we_can_evaluate_a_simple_column() {
     let expr = col("bigints");
     let actual_column = table.evaluate(&expr).unwrap();
     let expected_column = OwnedColumn::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
+        ColumnNullability::NotNullable,
         vec![i64::MIN, -1, 0, 1, i64::MAX],
     );
     assert_eq!(actual_column, expected_column);
@@ -73,7 +73,7 @@ fn we_can_evaluate_a_simple_column() {
     let expr = col("john");
     let actual_column = table.evaluate(&expr).unwrap();
     let expected_column = OwnedColumn::VarChar(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
+        ColumnNullability::NotNullable,
         ["John", "Juan", "João", "Jean", "Jean"]
             .iter()
             .map(ToString::to_string)
@@ -96,7 +96,7 @@ fn we_can_not_evaluate_a_nonexisting_column() {
 
 #[test]
 fn we_can_evaluate_a_logical_expression() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table: OwnedTable<Curve25519Scalar> = owned_table([
         varchar("en", ["Elizabeth", "John", "cat", "dog", "Munich"]),
         varchar("pl", ["Elżbieta", "Jan", "kot", "pies", "Monachium"]),
@@ -150,7 +150,7 @@ fn we_can_evaluate_a_logical_expression() {
 
 #[test]
 fn we_can_evaluate_an_arithmetic_expression() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table: OwnedTable<Curve25519Scalar> = owned_table([
         smallint("smallints", [-2_i16, -1, 0, 1, 2]),
         int("ints", [-4_i32, -2, 0, 2, 4]),

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -1,8 +1,7 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{
-        owned_table_utility::*, ColumnOperationError, ExpressionEvaluationError, OwnedColumn,
-        OwnedTable,
+        owned_table_utility::*, ColumnOperationError, ColumnTypeAssociatedData,
+        ExpressionEvaluationError, OwnedColumn, OwnedTable,
     },
     math::decimal::Precision,
     scalar::Curve25519Scalar,

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{
         owned_table_utility::*, ColumnOperationError, ExpressionEvaluationError, OwnedColumn,
@@ -12,7 +13,6 @@ use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
     utility::*,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_evaluate_a_simple_literal() {
@@ -51,7 +51,8 @@ fn we_can_evaluate_a_simple_literal() {
     // A group of people has about 0.67 cats per person
     let expr = lit("0.67".parse::<IntermediateDecimal>().unwrap());
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column = OwnedColumn::Decimal75(meta, Precision::new(2).unwrap(), 2, vec![67.into(); 5]);
+    let expected_column =
+        OwnedColumn::Decimal75(meta, Precision::new(2).unwrap(), 2, vec![67.into(); 5]);
     assert_eq!(actual_column, expected_column);
 }
 
@@ -64,7 +65,10 @@ fn we_can_evaluate_a_simple_column() {
     ]);
     let expr = col("bigints");
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column = OwnedColumn::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, vec![i64::MIN, -1, 0, 1, i64::MAX]);
+    let expected_column = OwnedColumn::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        vec![i64::MIN, -1, 0, 1, i64::MAX],
+    );
     assert_eq!(actual_column, expected_column);
 
     let expr = col("john");
@@ -181,7 +185,8 @@ fn we_can_evaluate_an_arithmetic_expression() {
         .iter()
         .map(|&x| x.into())
         .collect();
-    let expected_column = OwnedColumn::Decimal75(meta, Precision::new(9).unwrap(), 3, expected_scalars);
+    let expected_column =
+        OwnedColumn::Decimal75(meta, Precision::new(9).unwrap(), 3, expected_scalars);
     assert_eq!(actual_column, expected_column);
 
     // Decimals over 2.5 plus int128s
@@ -197,7 +202,8 @@ fn we_can_evaluate_an_arithmetic_expression() {
         .iter()
         .map(|&x| x.into())
         .collect();
-    let expected_column = OwnedColumn::Decimal75(meta, Precision::new(46).unwrap(), 6, expected_scalars);
+    let expected_column =
+        OwnedColumn::Decimal75(meta, Precision::new(46).unwrap(), 6, expected_scalars);
     assert_eq!(actual_column, expected_column);
 }
 

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -40,31 +40,41 @@ pub fn filter_column_by_index<'a, S: Scalar>(
     indexes: &[usize],
 ) -> Column<'a, S> {
     match column {
-        Column::Boolean(meta, col) => {
-            Column::Boolean(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::TinyInt(meta, col) => {
-            Column::TinyInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::SmallInt(meta, col) => {
-            Column::SmallInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::Int(meta, col) => {
-            Column::Int(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::BigInt(meta, col) => {
-            Column::BigInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::Int128(meta, col) => {
-            Column::Int128(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
-        Column::VarChar(meta, (col, scals)) => Column::VarChar(*meta, (
+        Column::Boolean(meta, col) => Column::Boolean(
+            *meta,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
-            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
-        )),
-        Column::Scalar(meta, col) => {
-            Column::Scalar(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
+        ),
+        Column::TinyInt(meta, col) => Column::TinyInt(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
+        Column::SmallInt(meta, col) => Column::SmallInt(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
+        Column::Int(meta, col) => Column::Int(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
+        Column::BigInt(meta, col) => Column::BigInt(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
+        Column::Int128(meta, col) => Column::Int128(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
+        Column::VarChar(meta, (col, scals)) => Column::VarChar(
+            *meta,
+            (
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+                alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
+            ),
+        ),
+        Column::Scalar(meta, col) => Column::Scalar(
+            *meta,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
         Column::Decimal75(meta, precision, scale, col) => Column::Decimal75(
             *meta,
             *precision,

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -40,37 +40,39 @@ pub fn filter_column_by_index<'a, S: Scalar>(
     indexes: &[usize],
 ) -> Column<'a, S> {
     match column {
-        Column::Boolean(col) => {
-            Column::Boolean(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::Boolean(meta, col) => {
+            Column::Boolean(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::TinyInt(col) => {
-            Column::TinyInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::TinyInt(meta, col) => {
+            Column::TinyInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::SmallInt(col) => {
-            Column::SmallInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::SmallInt(meta, col) => {
+            Column::SmallInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::Int(col) => {
-            Column::Int(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::Int(meta, col) => {
+            Column::Int(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::BigInt(col) => {
-            Column::BigInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::BigInt(meta, col) => {
+            Column::BigInt(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::Int128(col) => {
-            Column::Int128(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::Int128(meta, col) => {
+            Column::Int128(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::VarChar((col, scals)) => Column::VarChar((
+        Column::VarChar(meta, (col, scals)) => Column::VarChar(*meta, (
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
         )),
-        Column::Scalar(col) => {
-            Column::Scalar(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        Column::Scalar(meta, col) => {
+            Column::Scalar(*meta, alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
-        Column::Decimal75(precision, scale, col) => Column::Decimal75(
+        Column::Decimal75(meta, precision, scale, col) => Column::Decimal75(
+            *meta,
             *precision,
             *scale,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
-        Column::TimestampTZ(tu, tz, col) => Column::TimestampTZ(
+        Column::TimestampTZ(meta, tu, tz, col) => Column::TimestampTZ(
+            *meta,
             *tu,
             *tz,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    database::{filter_util::*, Column, ColumnTypeAssociatedData},
+    database::{filter_util::*, Column, ColumnNullability},
     math::decimal::Precision,
     scalar::Curve25519Scalar,
 };
@@ -7,7 +7,7 @@ use bumpalo::Bump;
 
 #[test]
 fn we_can_filter_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let selection = vec![true, false, true, false, true];
     let str_scalars: [Curve25519Scalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
@@ -44,7 +44,7 @@ fn we_can_filter_columns() {
 }
 #[test]
 fn we_can_filter_columns_with_empty_result() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let selection = vec![false, false, false, false, false];
     let str_scalars: [Curve25519Scalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
@@ -73,7 +73,7 @@ fn we_can_filter_columns_with_empty_result() {
 }
 #[test]
 fn we_can_filter_empty_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let selection = vec![];
     let columns = vec![
         Column::<Curve25519Scalar>::BigInt(meta, &[]),

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,10 +1,10 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
     scalar::Curve25519Scalar,
 };
 use bumpalo::Bump;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_filter_columns() {
@@ -29,9 +29,13 @@ fn we_can_filter_columns() {
         vec![
             Column::BigInt(meta, &[1, 3, 5]),
             Column::Int128(meta, &[1, 3, 5]),
-            Column::VarChar(meta, (&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
+            Column::VarChar(
+                meta,
+                (&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])
+            ),
             Column::Scalar(meta, &[1.into(), 3.into(), 5.into()]),
-            Column::Decimal75(meta,
+            Column::Decimal75(
+                meta,
                 Precision::new(75).unwrap(),
                 0,
                 &[1.into(), 3.into(), 5.into()]

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,6 +1,5 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
-    database::{filter_util::*, Column},
+    database::{filter_util::*, Column, ColumnTypeAssociatedData},
     math::decimal::Precision,
     scalar::Curve25519Scalar,
 };

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -4,20 +4,22 @@ use crate::base::{
     scalar::Curve25519Scalar,
 };
 use bumpalo::Bump;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_filter_columns() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let selection = vec![true, false, true, false, true];
     let str_scalars: [Curve25519Scalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[1, 2, 3, 4, 5]),
-        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
-        Column::Scalar(&scalars),
-        Column::Decimal75(Precision::new(75).unwrap(), 0, &decimals),
+        Column::BigInt(meta, &[1, 2, 3, 4, 5]),
+        Column::Int128(meta, &[1, 2, 3, 4, 5]),
+        Column::VarChar(meta, (&["1", "2", "3", "4", "5"], &str_scalars)),
+        Column::Scalar(meta, &scalars),
+        Column::Decimal75(meta, Precision::new(75).unwrap(), 0, &decimals),
     ];
     let alloc = Bump::new();
     let (result, len) = filter_columns(&alloc, &columns, &selection);
@@ -25,11 +27,11 @@ fn we_can_filter_columns() {
     assert_eq!(
         result,
         vec![
-            Column::BigInt(&[1, 3, 5]),
-            Column::Int128(&[1, 3, 5]),
-            Column::VarChar((&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
-            Column::Scalar(&[1.into(), 3.into(), 5.into()]),
-            Column::Decimal75(
+            Column::BigInt(meta, &[1, 3, 5]),
+            Column::Int128(meta, &[1, 3, 5]),
+            Column::VarChar(meta, (&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
+            Column::Scalar(meta, &[1.into(), 3.into(), 5.into()]),
+            Column::Decimal75(meta,
                 Precision::new(75).unwrap(),
                 0,
                 &[1.into(), 3.into(), 5.into()]
@@ -39,17 +41,18 @@ fn we_can_filter_columns() {
 }
 #[test]
 fn we_can_filter_columns_with_empty_result() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let selection = vec![false, false, false, false, false];
     let str_scalars: [Curve25519Scalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[1, 2, 3, 4, 5]),
-        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
-        Column::Scalar(&scalars),
-        Column::Decimal75(Precision::new(75).unwrap(), -1, &decimals),
+        Column::BigInt(meta, &[1, 2, 3, 4, 5]),
+        Column::Int128(meta, &[1, 2, 3, 4, 5]),
+        Column::VarChar(meta, (&["1", "2", "3", "4", "5"], &str_scalars)),
+        Column::Scalar(meta, &scalars),
+        Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &decimals),
     ];
     let alloc = Bump::new();
     let (result, len) = filter_columns(&alloc, &columns, &selection);
@@ -57,23 +60,24 @@ fn we_can_filter_columns_with_empty_result() {
     assert_eq!(
         result,
         vec![
-            Column::BigInt(&[]),
-            Column::Int128(&[]),
-            Column::VarChar((&[], &[])),
-            Column::Scalar(&[]),
-            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
+            Column::BigInt(meta, &[]),
+            Column::Int128(meta, &[]),
+            Column::VarChar(meta, (&[], &[])),
+            Column::Scalar(meta, &[]),
+            Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &[])
         ]
     );
 }
 #[test]
 fn we_can_filter_empty_columns() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let selection = vec![];
     let columns = vec![
-        Column::<Curve25519Scalar>::BigInt(&[]),
-        Column::Int128(&[]),
-        Column::VarChar((&[], &[])),
-        Column::Scalar(&[]),
-        Column::Decimal75(Precision::new(75).unwrap(), -1, &[]),
+        Column::<Curve25519Scalar>::BigInt(meta, &[]),
+        Column::Int128(meta, &[]),
+        Column::VarChar(meta, (&[], &[])),
+        Column::Scalar(meta, &[]),
+        Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &[]),
     ];
     let alloc = Bump::new();
     let (result, len) = filter_columns(&alloc, &columns, &selection);
@@ -81,11 +85,11 @@ fn we_can_filter_empty_columns() {
     assert_eq!(
         result,
         vec![
-            Column::BigInt(&[]),
-            Column::Int128(&[]),
-            Column::VarChar((&[], &[])),
-            Column::Scalar(&[]),
-            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
+            Column::BigInt(meta, &[]),
+            Column::Int128(meta, &[]),
+            Column::VarChar(meta, (&[], &[])),
+            Column::Scalar(meta, &[]),
+            Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &[])
         ]
     );
 }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -147,17 +147,17 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [S] {
     match column {
-        Column::TinyInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::BigInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int128(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Decimal75(_, _, col) => {
+        Column::TinyInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::BigInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int128(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Decimal75(_, _, _, col) => {
             sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
-        Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Scalar(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `SUM` function can only be applied to numeric types.
-        Column::VarChar(_) | Column::TimestampTZ(_, _, _) | Column::Boolean(_) => {
+        Column::VarChar(_, _) | Column::TimestampTZ(..) | Column::Boolean(..) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -175,21 +175,21 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [Option<S>] {
     match column {
-        Column::Boolean(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::TinyInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::BigInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int128(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Decimal75(_, _, col) => {
+        Column::Boolean(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::TinyInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::BigInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int128(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Decimal75(_, _, _, col) => {
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
-        Column::TimestampTZ(_, _, col) => {
+        Column::TimestampTZ(_, _, _, col) => {
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
-        Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Scalar(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `MAX` function can't be applied to varchar.
-        Column::VarChar(_) => {
+        Column::VarChar(_, _) => {
             unreachable!("MAX can not be applied to varchar")
         }
     }
@@ -207,21 +207,21 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [Option<S>] {
     match column {
-        Column::Boolean(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::TinyInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::BigInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Int128(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Decimal75(_, _, col) => {
+        Column::Boolean(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::TinyInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::BigInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Int128(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Decimal75(_, _, _, col) => {
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
-        Column::TimestampTZ(_, _, col) => {
+        Column::TimestampTZ(_, _, _, col) => {
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
-        Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Scalar(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `MIN` function can't be applied to varchar.
-        Column::VarChar(_) => {
+        Column::VarChar(_, _) => {
             unreachable!("MIN can not be applied to varchar")
         }
     }
@@ -361,15 +361,15 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
     group_by
         .iter()
         .map(|col| match col {
-            Column::Boolean(col) => col[i].cmp(&col[j]),
-            Column::TinyInt(col) => col[i].cmp(&col[j]),
-            Column::SmallInt(col) => col[i].cmp(&col[j]),
-            Column::Int(col) => col[i].cmp(&col[j]),
-            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
-            Column::Int128(col) => col[i].cmp(&col[j]),
-            Column::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
-            Column::Scalar(col) => col[i].cmp(&col[j]),
-            Column::VarChar((col, _)) => col[i].cmp(col[j]),
+            Column::Boolean(_, col) => col[i].cmp(&col[j]),
+            Column::TinyInt(_, col) => col[i].cmp(&col[j]),
+            Column::SmallInt(_, col) => col[i].cmp(&col[j]),
+            Column::Int(_, col) => col[i].cmp(&col[j]),
+            Column::BigInt(_, col) | Column::TimestampTZ(.., col) => col[i].cmp(&col[j]),
+            Column::Int128(_, col) => col[i].cmp(&col[j]),
+            Column::Decimal75(_, _, _, col) => col[i].signed_cmp(&col[j]),
+            Column::Scalar(_, col) => col[i].cmp(&col[j]),
+            Column::VarChar(_, (col, _)) => col[i].cmp(col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)
@@ -387,15 +387,15 @@ pub(crate) fn compare_indexes_by_owned_columns<S: Scalar>(
     group_by
         .iter()
         .map(|col| match col {
-            OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
-            OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
-            OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
-            OwnedColumn::Int(col) => col[i].cmp(&col[j]),
-            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
-            OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
-            OwnedColumn::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
-            OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
-            OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
+            OwnedColumn::Boolean(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::TinyInt(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::SmallInt(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::Int(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::BigInt(_, col) | OwnedColumn::TimestampTZ(.., col) => col[i].cmp(&col[j]),
+            OwnedColumn::Int128(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::Decimal75(.., col) => col[i].signed_cmp(&col[j]),
+            OwnedColumn::Scalar(_, col) => col[i].cmp(&col[j]),
+            OwnedColumn::VarChar(_, col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -148,7 +148,9 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [S] {
     match column {
         Column::TinyInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => {
+            sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
+        }
         Column::Int(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::BigInt(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int128(_, col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -177,7 +179,9 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
     match column {
         Column::Boolean(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => {
+            max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
+        }
         Column::Int(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::BigInt(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int128(_, col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -209,7 +213,9 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
     match column {
         Column::Boolean(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::SmallInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::SmallInt(_, col) => {
+            min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
+        }
         Column::Int(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::BigInt(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int128(_, col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{group_by_util::*, Column, ColumnTypeAssociatedData, OwnedColumn},
+        database::{group_by_util::*, Column, ColumnNullability, OwnedColumn},
         scalar::Curve25519Scalar,
     },
     proof_primitive::dory::DoryScalar,
@@ -10,7 +10,7 @@ use core::cmp::Ordering;
 
 #[test]
 fn we_can_aggregate_empty_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let column_a = Column::BigInt::<Curve25519Scalar>(meta, &[]);
     let column_b = Column::VarChar(meta, (&[], &[]));
     let column_c = Column::Int128(meta, &[]);
@@ -31,7 +31,7 @@ fn we_can_aggregate_empty_columns() {
 
 #[test]
 fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
     let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
     let selection = &[false; 12];
@@ -66,7 +66,7 @@ fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
 
 #[test]
 fn we_can_aggregate_columns_with_empty_group_by() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
     let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
     let selection = &[
@@ -116,7 +116,7 @@ fn we_can_aggregate_columns_with_empty_group_by() {
 
 #[test]
 fn we_can_aggregate_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[3, 3, 3, 2, 2, 1, 1, 2, 2, 3, 3, 3];
     let slice_b = &[
         "Cat", "Cat", "Dog", "Cat", "Dog", "Cat", "Dog", "Cat", "Dog", "Cat", "Dog", "Cat",
@@ -233,7 +233,7 @@ fn we_can_compare_indexes_by_columns_with_no_columns() {
 
 #[test]
 fn we_can_compare_indexes_by_columns_for_bigint_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
@@ -263,7 +263,7 @@ fn we_can_compare_indexes_by_columns_for_bigint_columns() {
 }
 #[test]
 fn we_can_compare_indexes_by_columns_for_mixed_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
@@ -294,7 +294,7 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
 }
 #[test]
 fn we_can_compare_indexes_by_owned_columns_for_mixed_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = ["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"]
         .into_iter()
         .map(Into::into)
@@ -375,7 +375,7 @@ fn we_can_compare_indexes_by_owned_columns_for_mixed_columns() {
 }
 #[test]
 fn we_can_compare_indexes_by_columns_for_scalar_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
@@ -483,7 +483,7 @@ fn we_can_sum_aggregate_slice_by_counts_without_empty_groups() {
 #[test]
 fn we_can_sum_aggregate_columns_by_counts_for_empty_column() {
     let slice_a: &[i64; 0] = &[];
-    let column_a = Column::BigInt::<DoryScalar>(ColumnTypeAssociatedData::NOT_NULLABLE, slice_a);
+    let column_a = Column::BigInt::<DoryScalar>(ColumnNullability::NotNullable, slice_a);
     let indexes = &[];
     let counts = &[];
     let expected: &[DoryScalar; 0] = &[];
@@ -495,7 +495,7 @@ fn we_can_sum_aggregate_columns_by_counts_for_empty_column() {
 
 #[test]
 fn we_can_sum_aggregate_columns_by_counts() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
@@ -603,7 +603,7 @@ fn we_can_max_aggregate_slice_by_counts_without_empty_groups() {
 #[test]
 fn we_can_max_aggregate_columns_by_counts_for_empty_column() {
     let slice_a: &[i64; 0] = &[];
-    let column_a = Column::BigInt::<DoryScalar>(ColumnTypeAssociatedData::NOT_NULLABLE, slice_a);
+    let column_a = Column::BigInt::<DoryScalar>(ColumnNullability::NotNullable, slice_a);
     let indexes = &[];
     let counts = &[];
     let expected: &[Option<DoryScalar>; 0] = &[];
@@ -615,7 +615,7 @@ fn we_can_max_aggregate_columns_by_counts_for_empty_column() {
 
 #[test]
 fn we_can_max_aggregate_columns_by_counts() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
@@ -724,7 +724,7 @@ fn we_can_min_aggregate_slice_by_counts_without_empty_groups() {
 #[test]
 fn we_can_min_aggregate_columns_by_counts_for_empty_column() {
     let slice_a: &[i64; 0] = &[];
-    let column_a = Column::BigInt::<DoryScalar>(ColumnTypeAssociatedData::NOT_NULLABLE, slice_a);
+    let column_a = Column::BigInt::<DoryScalar>(ColumnNullability::NotNullable, slice_a);
     let indexes = &[];
     let counts = &[];
     let expected: &[Option<DoryScalar>; 0] = &[];
@@ -736,7 +736,7 @@ fn we_can_min_aggregate_columns_by_counts_for_empty_column() {
 
 #[test]
 fn we_can_min_aggregate_columns_by_counts() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let slice_a = &[
         100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
     ];

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,7 +1,6 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
-        database::{group_by_util::*, Column, OwnedColumn},
+        database::{group_by_util::*, Column, ColumnTypeAssociatedData, OwnedColumn},
         scalar::Curve25519Scalar,
     },
     proof_primitive::dory::DoryScalar,

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{group_by_util::*, Column, OwnedColumn},
@@ -7,7 +8,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::cmp::Ordering;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_aggregate_empty_columns() {
@@ -157,7 +157,10 @@ fn we_can_aggregate_columns() {
     ];
     let expected_group_by_result = &[
         Column::BigInt(meta, &[1, 1, 2, 2, 3, 3]),
-        Column::VarChar(meta, (&["Cat", "Dog", "Cat", "Dog", "Cat", "Dog"], &scals_res)),
+        Column::VarChar(
+            meta,
+            (&["Cat", "Dog", "Cat", "Dog", "Cat", "Dog"], &scals_res),
+        ),
     ];
     let expected_sum_result = &[
         &[

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -2,6 +2,7 @@ use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar
 use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Represents a literal value.
 ///
@@ -42,16 +43,24 @@ impl<S: Scalar> LiteralValue<S> {
     /// Provides the column type associated with the column
     pub fn column_type(&self) -> ColumnType {
         match self {
-            Self::Boolean(_) => ColumnType::Boolean,
-            Self::TinyInt(_) => ColumnType::TinyInt,
-            Self::SmallInt(_) => ColumnType::SmallInt,
-            Self::Int(_) => ColumnType::Int,
-            Self::BigInt(_) => ColumnType::BigInt,
-            Self::VarChar(_) => ColumnType::VarChar,
-            Self::Int128(_) => ColumnType::Int128,
-            Self::Scalar(_) => ColumnType::Scalar,
-            Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(*precision, *scale),
-            Self::TimeStampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
+            Self::Boolean(_) => ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::TinyInt(_) => ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::SmallInt(_) => ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::Int(_) => ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::BigInt(_) => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::VarChar(_) => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::Int128(_) => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::Scalar(_) => ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                *precision,
+                *scale
+            ),
+            Self::TimeStampTZ(tu, tz, _) => ColumnType::TimestampTZ(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                *tu,
+                *tz
+            ),
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,5 +1,8 @@
-use crate::base::database::ColumnTypeAssociatedData;
-use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
+use crate::base::{
+    database::{ColumnType, ColumnTypeAssociatedData},
+    math::decimal::Precision,
+    scalar::Scalar,
+};
 use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    database::{ColumnType, ColumnTypeAssociatedData},
+    database::{ColumnNullability, ColumnType},
     math::decimal::Precision,
     scalar::Scalar,
 };
@@ -46,19 +46,19 @@ impl<S: Scalar> LiteralValue<S> {
     /// Provides the column type associated with the column
     pub fn column_type(&self) -> ColumnType {
         match self {
-            Self::Boolean(_) => ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::TinyInt(_) => ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::SmallInt(_) => ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::Int(_) => ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::BigInt(_) => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::VarChar(_) => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::Int128(_) => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::Scalar(_) => ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            Self::Boolean(_) => ColumnType::Boolean(ColumnNullability::NotNullable),
+            Self::TinyInt(_) => ColumnType::TinyInt(ColumnNullability::NotNullable),
+            Self::SmallInt(_) => ColumnType::SmallInt(ColumnNullability::NotNullable),
+            Self::Int(_) => ColumnType::Int(ColumnNullability::NotNullable),
+            Self::BigInt(_) => ColumnType::BigInt(ColumnNullability::NotNullable),
+            Self::VarChar(_) => ColumnType::VarChar(ColumnNullability::NotNullable),
+            Self::Int128(_) => ColumnType::Int128(ColumnNullability::NotNullable),
+            Self::Scalar(_) => ColumnType::Scalar(ColumnNullability::NotNullable),
             Self::Decimal75(precision, scale, _) => {
-                ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, *precision, *scale)
+                ColumnType::Decimal75(ColumnNullability::NotNullable, *precision, *scale)
             }
             Self::TimeStampTZ(tu, tz, _) => {
-                ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, *tu, *tz)
+                ColumnType::TimestampTZ(ColumnNullability::NotNullable, *tu, *tz)
             }
         }
     }

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,8 +1,8 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
 use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Represents a literal value.
 ///
@@ -51,16 +51,12 @@ impl<S: Scalar> LiteralValue<S> {
             Self::VarChar(_) => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
             Self::Int128(_) => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
             Self::Scalar(_) => ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                *precision,
-                *scale
-            ),
-            Self::TimeStampTZ(tu, tz, _) => ColumnType::TimestampTZ(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                *tu,
-                *tz
-            ),
+            Self::Decimal75(precision, scale, _) => {
+                ColumnType::Decimal75(ColumnTypeAssociatedData::NOT_NULLABLE, *precision, *scale)
+            }
+            Self::TimeStampTZ(tu, tz, _) => {
+                ColumnType::TimestampTZ(ColumnTypeAssociatedData::NOT_NULLABLE, *tu, *tz)
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -5,7 +5,7 @@ mod accessor;
 pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor};
 
 mod column;
-pub use column::{Column, ColumnField, ColumnNullability, ColumnRef, ColumnType};
+pub use column::{Column, ColumnField, ColumnNullability, ColumnRef, ColumnType, ColumnTypeKind};
 
 mod column_operation;
 pub use column_operation::{

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -5,7 +5,7 @@ mod accessor;
 pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor};
 
 mod column;
-pub use column::{Column, ColumnField, ColumnRef, ColumnType};
+pub use column::{Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData};
 
 mod column_operation;
 pub use column_operation::{

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -5,7 +5,7 @@ mod accessor;
 pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor};
 
 mod column;
-pub use column::{Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData};
+pub use column::{Column, ColumnField, ColumnNullability, ColumnRef, ColumnType};
 
 mod column_operation;
 pub use column_operation::{

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -13,6 +13,7 @@
 //! This does not check that the values are less than 39 digits.
 //! However, the actual arrow backing `i128` is the correct value.
 use super::scalar_and_i256_conversions::convert_scalar_to_i256;
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{
         scalar_and_i256_conversions::convert_i256_to_scalar, OwnedColumn, OwnedTable,
@@ -38,7 +39,6 @@ use proof_of_sql_parser::{
     Identifier, ParseError,
 };
 use snafu::Snafu;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[derive(Snafu, Debug)]
 #[non_exhaustive]

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -13,11 +13,10 @@
 //! This does not check that the values are less than 39 digits.
 //! However, the actual arrow backing `i128` is the correct value.
 use super::scalar_and_i256_conversions::convert_scalar_to_i256;
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{
-        scalar_and_i256_conversions::convert_i256_to_scalar, OwnedColumn, OwnedTable,
-        OwnedTableError,
+        scalar_and_i256_conversions::convert_i256_to_scalar, ColumnTypeAssociatedData, OwnedColumn,
+        OwnedTable, OwnedTableError,
     },
     map::IndexMap,
     math::decimal::Precision,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -15,7 +15,7 @@
 use super::scalar_and_i256_conversions::convert_scalar_to_i256;
 use crate::base::{
     database::{
-        scalar_and_i256_conversions::convert_i256_to_scalar, ColumnTypeAssociatedData, OwnedColumn,
+        scalar_and_i256_conversions::convert_i256_to_scalar, ColumnNullability, OwnedColumn,
         OwnedTable, OwnedTableError,
     },
     map::IndexMap,
@@ -155,7 +155,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
             // Arrow uses a bit-packed representation for booleans.
             // Hence we need to unpack the bits to get the actual boolean values.
             DataType::Boolean => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<BooleanArray>()
@@ -165,7 +165,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .ok_or(OwnedArrowConversionError::NullNotSupportedYet)?,
             )),
             DataType::Int8 => Ok(Self::TinyInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<Int8Array>()
@@ -174,7 +174,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .to_vec(),
             )),
             DataType::Int16 => Ok(Self::SmallInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<Int16Array>()
@@ -183,7 +183,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .to_vec(),
             )),
             DataType::Int32 => Ok(Self::Int(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<Int32Array>()
@@ -192,7 +192,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .to_vec(),
             )),
             DataType::Int64 => Ok(Self::BigInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<Int64Array>()
@@ -201,7 +201,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .to_vec(),
             )),
             DataType::Decimal128(38, 0) => Ok(Self::Int128(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<Decimal128Array>()
@@ -210,7 +210,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .to_vec(),
             )),
             DataType::Decimal256(precision, scale) if *precision <= 75 => Ok(Self::Decimal75(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 Precision::new(*precision).expect("precision is less than 76"),
                 *scale,
                 value
@@ -224,7 +224,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .collect(),
             )),
             DataType::Utf8 => Ok(Self::VarChar(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 value
                     .as_any()
                     .downcast_ref::<StringArray>()
@@ -243,7 +243,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         );
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ColumnTypeAssociatedData::NOT_NULLABLE,
+                        ColumnNullability::NotNullable,
                         PoSQLTimeUnit::Second,
                         PoSQLTimeZone::try_from(timezone)?,
                         timestamps,
@@ -258,7 +258,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         );
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ColumnTypeAssociatedData::NOT_NULLABLE,
+                        ColumnNullability::NotNullable,
                         PoSQLTimeUnit::Millisecond,
                         PoSQLTimeZone::try_from(timezone)?,
                         timestamps,
@@ -273,7 +273,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         );
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ColumnTypeAssociatedData::NOT_NULLABLE,
+                        ColumnNullability::NotNullable,
                         PoSQLTimeUnit::Microsecond,
                         PoSQLTimeZone::try_from(timezone)?,
                         timestamps,
@@ -288,7 +288,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         );
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ColumnTypeAssociatedData::NOT_NULLABLE,
+                        ColumnNullability::NotNullable,
                         PoSQLTimeUnit::Nanosecond,
                         PoSQLTimeZone::try_from(timezone)?,
                         timestamps,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -26,19 +26,28 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 }
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
+        OwnedColumn::<Curve25519Scalar>::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.clone(),
+        ),
         Arc::new(BooleanArray::from(data)),
     );
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
+        OwnedColumn::<Curve25519Scalar>::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.clone(),
+        ),
         Arc::new(Int64Array::from(data)),
     );
 }
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
+        OwnedColumn::<Curve25519Scalar>::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.clone(),
+        ),
         Arc::new(
             Decimal128Array::from(data)
                 .with_precision_and_scale(38, 0)
@@ -48,7 +57,10 @@ fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>
 }
 fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<String>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
+        OwnedColumn::<Curve25519Scalar>::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.clone(),
+        ),
         Arc::new(StringArray::from(data)),
     );
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -1,4 +1,4 @@
-use super::{ColumnTypeAssociatedData, OwnedColumn, OwnedTable};
+use super::{ColumnNullability, OwnedColumn, OwnedTable};
 use crate::{
     base::{
         database::{owned_table_utility::*, OwnedArrowConversionError},
@@ -26,28 +26,19 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 }
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            data.clone(),
-        ),
+        OwnedColumn::<Curve25519Scalar>::Boolean(ColumnNullability::NotNullable, data.clone()),
         Arc::new(BooleanArray::from(data)),
     );
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            data.clone(),
-        ),
+        OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, data.clone()),
         Arc::new(Int64Array::from(data)),
     );
 }
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            data.clone(),
-        ),
+        OwnedColumn::<Curve25519Scalar>::Int128(ColumnNullability::NotNullable, data.clone()),
         Arc::new(
             Decimal128Array::from(data)
                 .with_precision_and_scale(38, 0)
@@ -57,10 +48,7 @@ fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>
 }
 fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<String>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            data.clone(),
-        ),
+        OwnedColumn::<Curve25519Scalar>::VarChar(ColumnNullability::NotNullable, data.clone()),
         Arc::new(StringArray::from(data)),
     );
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -32,7 +32,7 @@ fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        &OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable,, data.clone()),
+        &OwnedColumn::<Curve25519Scalar>::BigInt(ColumnNullability::NotNullable, data.clone()),
         Arc::new(Int64Array::from(data)),
     );
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -1,4 +1,4 @@
-use super::{OwnedColumn, OwnedTable};
+use super::{ColumnTypeAssociatedData, OwnedColumn, OwnedTable};
 use crate::{
     base::{
         database::{owned_table_utility::*, OwnedArrowConversionError},
@@ -26,19 +26,19 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 }
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Boolean(data.clone()),
+        OwnedColumn::<Curve25519Scalar>::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
         Arc::new(BooleanArray::from(data)),
     );
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::BigInt(data.clone()),
+        OwnedColumn::<Curve25519Scalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
         Arc::new(Int64Array::from(data)),
     );
 }
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Int128(data.clone()),
+        OwnedColumn::<Curve25519Scalar>::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
         Arc::new(
             Decimal128Array::from(data)
                 .with_precision_and_scale(38, 0)
@@ -48,7 +48,7 @@ fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>
 }
 fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<String>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::VarChar(data.clone()),
+        OwnedColumn::<Curve25519Scalar>::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, data.clone()),
         Arc::new(StringArray::from(data)),
     );
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -112,7 +112,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::TinyInt(_, col) => col.is_empty(),
             OwnedColumn::SmallInt(_, col) => col.is_empty(),
             OwnedColumn::Int(_, col) => col.is_empty(),
-            OwnedColumn::BigInt(meta, col) | OwnedColumn::TimestampTZ(_,_, _, col) => col.is_empty(),
+            OwnedColumn::BigInt(_, col) | OwnedColumn::TimestampTZ(_,_, _, col) => col.is_empty(),
             OwnedColumn::VarChar(_, col) => col.is_empty(),
             OwnedColumn::Int128(_, col) => col.is_empty(),
             OwnedColumn::Scalar(_, col) | OwnedColumn::Decimal75(_, _, _, col) => col.is_empty(),

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -218,7 +218,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             // Can not convert scalars to VarChar
             ColumnType::VarChar(meta) => Err(OwnedColumnError::TypeCastError {
-                from_type: ColumnType::Scalar(ColumnTypeAssociatedData::default()),
+                from_type: ColumnType::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE),
                 to_type: ColumnType::VarChar(meta),
             }),
         }
@@ -377,14 +377,14 @@ mod test {
 
     #[test]
     fn we_can_slice_a_column() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(meta, vec![1, 2, 3, 4, 5]);
         assert_eq!(col.slice(1, 4), OwnedColumn::Int128(meta, vec![2, 3, 4]));
     }
 
     #[test]
     fn we_can_permute_a_column() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let col: OwnedColumn<Curve25519Scalar> = OwnedColumn::Int128(meta, vec![1, 2, 3, 4, 5]);
         let permutation = Permutation::try_new(vec![1, 3, 4, 0, 2]).unwrap();
         assert_eq!(
@@ -395,7 +395,7 @@ mod test {
 
     #[test]
     fn we_can_compare_columns() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let col1: OwnedColumn<Curve25519Scalar> = OwnedColumn::SmallInt(meta, vec![1, 1, 2, 1, 1]);
         let col2: OwnedColumn<Curve25519Scalar> = OwnedColumn::VarChar(
             meta,
@@ -442,7 +442,7 @@ mod test {
 
     #[test]
     fn we_can_convert_columns_to_owned_columns_round_trip() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let alloc = Bump::new();
         // Integers
         let col: Column<'_, Curve25519Scalar> = Column::Int128(meta, &[1, 2, 3, 4, 5]);
@@ -501,7 +501,7 @@ mod test {
 
     #[test]
     fn we_can_convert_scalars_to_owned_columns() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Int
         let scalars = [1, 2, 3, 4, 5]
             .iter()
@@ -542,7 +542,7 @@ mod test {
             .iter()
             .map(Curve25519Scalar::from)
             .collect::<Vec<_>>();
-        let column_type = ColumnType::VarChar(ColumnTypeAssociatedData::default());
+        let column_type = ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE);
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
         assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
     }
@@ -554,7 +554,7 @@ mod test {
             .iter()
             .map(Curve25519Scalar::from)
             .collect::<Vec<_>>();
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let column_type = ColumnType::BigInt(meta);
         let res = OwnedColumn::try_from_scalars(&scalars, column_type);
         assert!(matches!(
@@ -577,7 +577,7 @@ mod test {
 
     #[test]
     fn we_can_convert_option_scalars_to_owned_columns() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Int
         let option_scalars = [Some(1), Some(2), Some(3), Some(4), Some(5)]
             .iter()
@@ -622,14 +622,14 @@ mod test {
             .iter()
             .map(|s| Some(Curve25519Scalar::from(*s)))
             .collect::<Vec<_>>();
-        let column_type = ColumnType::VarChar(ColumnTypeAssociatedData::default());
+        let column_type = ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE);
         let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
         assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
     }
 
     #[test]
     fn we_cannot_convert_option_scalars_to_owned_columns_if_overflow() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Int
         let option_scalars = [
             Some(i128::MAX),
@@ -669,7 +669,7 @@ mod test {
 
     #[test]
     fn we_cannot_convert_option_scalars_to_owned_columns_if_none() {
-        let meta = ColumnTypeAssociatedData::default();
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Int
         let option_scalars = [Some(1), Some(2), None, Some(4), Some(5)]
             .iter()

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -52,33 +52,33 @@ impl<S: Scalar> OwnedColumn<S> {
     #[must_use]
     pub fn len(&self) -> usize {
         match self {
-            OwnedColumn::Boolean(col) => col.len(),
-            OwnedColumn::TinyInt(col) => col.len(),
-            OwnedColumn::SmallInt(col) => col.len(),
-            OwnedColumn::Int(col) => col.len(),
-            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
-            OwnedColumn::VarChar(col) => col.len(),
-            OwnedColumn::Int128(col) => col.len(),
-            OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.len(),
+            OwnedColumn::Boolean(_, col) => col.len(),
+            OwnedColumn::TinyInt(_, col) => col.len(),
+            OwnedColumn::SmallInt(_, col) => col.len(),
+            OwnedColumn::Int(_, col) => col.len(),
+            OwnedColumn::BigInt(_, col) | OwnedColumn::TimestampTZ(_, _, _, col) => col.len(),
+            OwnedColumn::VarChar(_, col) => col.len(),
+            OwnedColumn::Int128(_, col) => col.len(),
+            OwnedColumn::Decimal75(_, _, _, col) | OwnedColumn::Scalar(_, col) => col.len(),
         }
     }
 
     /// Returns the column with its entries permutated
     pub fn try_permute(&self, permutation: &Permutation) -> Result<Self, PermutationError> {
         Ok(match self {
-            OwnedColumn::Boolean(col) => OwnedColumn::Boolean(permutation.try_apply(col)?),
-            OwnedColumn::TinyInt(col) => OwnedColumn::TinyInt(permutation.try_apply(col)?),
-            OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(permutation.try_apply(col)?),
-            OwnedColumn::Int(col) => OwnedColumn::Int(permutation.try_apply(col)?),
-            OwnedColumn::BigInt(col) => OwnedColumn::BigInt(permutation.try_apply(col)?),
-            OwnedColumn::VarChar(col) => OwnedColumn::VarChar(permutation.try_apply(col)?),
-            OwnedColumn::Int128(col) => OwnedColumn::Int128(permutation.try_apply(col)?),
-            OwnedColumn::Decimal75(precision, scale, col) => {
-                OwnedColumn::Decimal75(*precision, *scale, permutation.try_apply(col)?)
+            OwnedColumn::Boolean(meta, col) => OwnedColumn::Boolean(*meta, permutation.try_apply(col)?),
+            OwnedColumn::TinyInt(meta, col) => OwnedColumn::TinyInt(*meta, permutation.try_apply(col)?),
+            OwnedColumn::SmallInt(meta, col) => OwnedColumn::SmallInt(*meta, permutation.try_apply(col)?),
+            OwnedColumn::Int(meta, col) => OwnedColumn::Int(*meta, permutation.try_apply(col)?),
+            OwnedColumn::BigInt(meta, col) => OwnedColumn::BigInt(*meta, permutation.try_apply(col)?),
+            OwnedColumn::VarChar(meta, col) => OwnedColumn::VarChar(*meta, permutation.try_apply(col)?),
+            OwnedColumn::Int128(meta, col) => OwnedColumn::Int128(*meta, permutation.try_apply(col)?),
+            OwnedColumn::Decimal75(meta, precision, scale, col) => {
+                OwnedColumn::Decimal75(*meta, *precision, *scale, permutation.try_apply(col)?)
             }
-            OwnedColumn::Scalar(col) => OwnedColumn::Scalar(permutation.try_apply(col)?),
-            OwnedColumn::TimestampTZ(tu, tz, col) => {
-                OwnedColumn::TimestampTZ(*tu, *tz, permutation.try_apply(col)?)
+            OwnedColumn::Scalar(meta, col) => OwnedColumn::Scalar(*meta, permutation.try_apply(col)?),
+            OwnedColumn::TimestampTZ(meta, tu, tz, col) => {
+                OwnedColumn::TimestampTZ(*meta, *tu, *tz, permutation.try_apply(col)?)
             }
         })
     }
@@ -87,19 +87,19 @@ impl<S: Scalar> OwnedColumn<S> {
     #[must_use]
     pub fn slice(&self, start: usize, end: usize) -> Self {
         match self {
-            OwnedColumn::Boolean(col) => OwnedColumn::Boolean(col[start..end].to_vec()),
-            OwnedColumn::TinyInt(col) => OwnedColumn::TinyInt(col[start..end].to_vec()),
-            OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(col[start..end].to_vec()),
-            OwnedColumn::Int(col) => OwnedColumn::Int(col[start..end].to_vec()),
-            OwnedColumn::BigInt(col) => OwnedColumn::BigInt(col[start..end].to_vec()),
-            OwnedColumn::VarChar(col) => OwnedColumn::VarChar(col[start..end].to_vec()),
-            OwnedColumn::Int128(col) => OwnedColumn::Int128(col[start..end].to_vec()),
-            OwnedColumn::Decimal75(precision, scale, col) => {
-                OwnedColumn::Decimal75(*precision, *scale, col[start..end].to_vec())
+            OwnedColumn::Boolean(meta, col) => OwnedColumn::Boolean(*meta, col[start..end].to_vec()),
+            OwnedColumn::TinyInt(meta, col) => OwnedColumn::TinyInt(*meta, col[start..end].to_vec()),
+            OwnedColumn::SmallInt(meta, col) => OwnedColumn::SmallInt(*meta, col[start..end].to_vec()),
+            OwnedColumn::Int(meta, col) => OwnedColumn::Int(*meta, col[start..end].to_vec()),
+            OwnedColumn::BigInt(meta, col) => OwnedColumn::BigInt(*meta, col[start..end].to_vec()),
+            OwnedColumn::VarChar(meta, col) => OwnedColumn::VarChar(*meta, col[start..end].to_vec()),
+            OwnedColumn::Int128(meta, col) => OwnedColumn::Int128(*meta, col[start..end].to_vec()),
+            OwnedColumn::Decimal75(meta, precision, scale, col) => {
+                OwnedColumn::Decimal75(*meta, *precision, *scale, col[start..end].to_vec())
             }
-            OwnedColumn::Scalar(col) => OwnedColumn::Scalar(col[start..end].to_vec()),
-            OwnedColumn::TimestampTZ(tu, tz, col) => {
-                OwnedColumn::TimestampTZ(*tu, *tz, col[start..end].to_vec())
+            OwnedColumn::Scalar(meta, col) => OwnedColumn::Scalar(*meta, col[start..end].to_vec()),
+            OwnedColumn::TimestampTZ(meta, tu, tz, col) => {
+                OwnedColumn::TimestampTZ(*meta, *tu, *tz, col[start..end].to_vec())
             }
         }
     }
@@ -108,39 +108,41 @@ impl<S: Scalar> OwnedColumn<S> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {
-            OwnedColumn::Boolean(col) => col.is_empty(),
-            OwnedColumn::TinyInt(col) => col.is_empty(),
-            OwnedColumn::SmallInt(col) => col.is_empty(),
-            OwnedColumn::Int(col) => col.is_empty(),
-            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
-            OwnedColumn::VarChar(col) => col.is_empty(),
-            OwnedColumn::Int128(col) => col.is_empty(),
-            OwnedColumn::Scalar(col) | OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
+            OwnedColumn::Boolean(_, col) => col.is_empty(),
+            OwnedColumn::TinyInt(_, col) => col.is_empty(),
+            OwnedColumn::SmallInt(_, col) => col.is_empty(),
+            OwnedColumn::Int(_, col) => col.is_empty(),
+            OwnedColumn::BigInt(meta, col) | OwnedColumn::TimestampTZ(_,_, _, col) => col.is_empty(),
+            OwnedColumn::VarChar(_, col) => col.is_empty(),
+            OwnedColumn::Int128(_, col) => col.is_empty(),
+            OwnedColumn::Scalar(_, col) | OwnedColumn::Decimal75(_, _, _, col) => col.is_empty(),
         }
     }
     /// Returns the type of the column.
     #[must_use]
     pub fn column_type(&self) -> ColumnType {
         match self {
-            OwnedColumn::Boolean(_) => ColumnType::Boolean,
-            OwnedColumn::TinyInt(_) => ColumnType::TinyInt,
-            OwnedColumn::SmallInt(_) => ColumnType::SmallInt,
-            OwnedColumn::Int(_) => ColumnType::Int,
-            OwnedColumn::BigInt(_) => ColumnType::BigInt,
-            OwnedColumn::VarChar(_) => ColumnType::VarChar,
-            OwnedColumn::Int128(_) => ColumnType::Int128,
-            OwnedColumn::Scalar(_) => ColumnType::Scalar,
-            OwnedColumn::Decimal75(precision, scale, _) => {
-                ColumnType::Decimal75(*precision, *scale)
+            OwnedColumn::Boolean(meta, _) => ColumnType::Boolean(*meta),
+            OwnedColumn::TinyInt(meta, _) => ColumnType::TinyInt(*meta),
+            OwnedColumn::SmallInt(meta, _) => ColumnType::SmallInt(*meta),
+            OwnedColumn::Int(meta, _) => ColumnType::Int(*meta),
+            OwnedColumn::BigInt(meta, _) => ColumnType::BigInt(*meta),
+            OwnedColumn::VarChar(meta, _) => ColumnType::VarChar(*meta),
+            OwnedColumn::Int128(meta, _) => ColumnType::Int128(*meta),
+            OwnedColumn::Scalar(meta, _) => ColumnType::Scalar(*meta),
+            OwnedColumn::Decimal75(meta, precision, scale, _) => {
+                ColumnType::Decimal75(*meta, *precision, *scale)
             }
-            OwnedColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
+            OwnedColumn::TimestampTZ(meta, tu, tz, _) =>
+                ColumnType::TimestampTZ(*meta, *tu, *tz),
         }
     }
 
     /// Convert a slice of scalars to a vec of owned columns
     pub fn try_from_scalars(scalars: &[S], column_type: ColumnType) -> OwnedColumnResult<Self> {
         match column_type {
-            ColumnType::Boolean => Ok(OwnedColumn::Boolean(
+            ColumnType::Boolean(meta) => Ok(OwnedColumn::Boolean(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<bool, _> { TryInto::<bool>::try_into(*s) })
@@ -149,7 +151,8 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::TinyInt => Ok(OwnedColumn::TinyInt(
+            ColumnType::TinyInt(meta) => Ok(OwnedColumn::TinyInt(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<i8, _> { TryInto::<i8>::try_into(*s) })
@@ -158,7 +161,8 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::SmallInt => Ok(OwnedColumn::SmallInt(
+            ColumnType::SmallInt(meta) => Ok(OwnedColumn::SmallInt(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<i16, _> { TryInto::<i16>::try_into(*s) })
@@ -167,7 +171,8 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::Int => Ok(OwnedColumn::Int(
+            ColumnType::Int(meta) => Ok(OwnedColumn::Int(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<i32, _> { TryInto::<i32>::try_into(*s) })
@@ -176,7 +181,8 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::BigInt => Ok(OwnedColumn::BigInt(
+            ColumnType::BigInt(meta) => Ok(OwnedColumn::BigInt(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
@@ -185,7 +191,8 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::Int128 => Ok(OwnedColumn::Int128(
+            ColumnType::Int128(meta) => Ok(OwnedColumn::Int128(
+                meta,
                 scalars
                     .iter()
                     .map(|s| -> Result<i128, _> { TryInto::<i128>::try_into(*s) })
@@ -194,11 +201,12 @@ impl<S: Scalar> OwnedColumn<S> {
                         error: "Overflow in scalar conversions".to_string(),
                     })?,
             )),
-            ColumnType::Scalar => Ok(OwnedColumn::Scalar(scalars.to_vec())),
-            ColumnType::Decimal75(precision, scale) => {
-                Ok(OwnedColumn::Decimal75(precision, scale, scalars.to_vec()))
+            ColumnType::Scalar(meta) => Ok(OwnedColumn::Scalar(
+                meta,scalars.to_vec())),
+            ColumnType::Decimal75(meta, precision, scale) => {
+                Ok(OwnedColumn::Decimal75(meta, precision, scale, scalars.to_vec()))
             }
-            ColumnType::TimestampTZ(tu, tz) => {
+            ColumnType::TimestampTZ(meta, tu, tz) => {
                 let raw_values: Vec<i64> = scalars
                     .iter()
                     .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
@@ -206,12 +214,12 @@ impl<S: Scalar> OwnedColumn<S> {
                     .map_err(|_| OwnedColumnError::ScalarConversionError {
                         error: "Overflow in scalar conversions".to_string(),
                     })?;
-                Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
+                Ok(OwnedColumn::TimestampTZ(meta, tu, tz, raw_values))
             }
             // Can not convert scalars to VarChar
-            ColumnType::VarChar => Err(OwnedColumnError::TypeCastError {
-                from_type: ColumnType::Scalar,
-                to_type: ColumnType::VarChar,
+            ColumnType::VarChar(meta) => Err(OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Scalar(ColumnTypeAssociatedData::default()),
+                to_type: ColumnType::VarChar(meta),
             }),
         }
     }
@@ -236,7 +244,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [i8], panicking if it is not.
     pub fn i8_iter(&self) -> impl Iterator<Item = &i8> {
         match self {
-            OwnedColumn::TinyInt(col) => col.iter(),
+            OwnedColumn::TinyInt(_, col) => col.iter(),
             _ => panic!("Expected TinyInt column"),
         }
     }
@@ -245,7 +253,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [i16], panicking if it is not.
     pub fn i16_iter(&self) -> impl Iterator<Item = &i16> {
         match self {
-            OwnedColumn::SmallInt(col) => col.iter(),
+            OwnedColumn::SmallInt(_, col) => col.iter(),
             _ => panic!("Expected SmallInt column"),
         }
     }
@@ -254,7 +262,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [i32], panicking if it is not.
     pub fn i32_iter(&self) -> impl Iterator<Item = &i32> {
         match self {
-            OwnedColumn::Int(col) => col.iter(),
+            OwnedColumn::Int(_, col) => col.iter(),
             _ => panic!("Expected Int column"),
         }
     }
@@ -263,7 +271,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [i64], panicking if it is not.
     pub fn i64_iter(&self) -> impl Iterator<Item = &i64> {
         match self {
-            OwnedColumn::TimestampTZ(_, _, col) | OwnedColumn::BigInt(col) => col.iter(),
+            OwnedColumn::TimestampTZ(_, _, _, col) | OwnedColumn::BigInt(_, col) => col.iter(),
             _ => panic!("Expected TimestampTZ or BigInt column"),
         }
     }
@@ -272,7 +280,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [i128], panicking if it is not.
     pub fn i128_iter(&self) -> impl Iterator<Item = &i128> {
         match self {
-            OwnedColumn::Int128(col) => col.iter(),
+            OwnedColumn::Int128(_, col) => col.iter(),
             _ => panic!("Expected Int128 column"),
         }
     }
@@ -281,7 +289,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [bool], panicking if it is not.
     pub fn bool_iter(&self) -> impl Iterator<Item = &bool> {
         match self {
-            OwnedColumn::Boolean(col) => col.iter(),
+            OwnedColumn::Boolean(_, col) => col.iter(),
             _ => panic!("Expected Boolean column"),
         }
     }
@@ -290,7 +298,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is a [Scalar], panicking if it is not.
     pub fn scalar_iter(&self) -> impl Iterator<Item = &S> {
         match self {
-            OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.iter(),
+            OwnedColumn::Decimal75(_, _, _, col) | OwnedColumn::Scalar(_, col) => col.iter(),
             _ => panic!("Expected Scalar or Decimal75 column"),
         }
     }
@@ -299,7 +307,7 @@ impl<S: Scalar> OwnedColumn<S> {
     /// assuming the underlying type is [String], panicking if it is not.
     pub fn string_iter(&self) -> impl Iterator<Item = &String> {
         match self {
-            OwnedColumn::VarChar(col) => col.iter(),
+            OwnedColumn::VarChar(_, col) => col.iter(),
             _ => panic!("Expected VarChar column"),
         }
     }
@@ -308,20 +316,21 @@ impl<S: Scalar> OwnedColumn<S> {
 impl<'a, S: Scalar> From<&Column<'a, S>> for OwnedColumn<S> {
     fn from(col: &Column<'a, S>) -> Self {
         match col {
-            Column::Boolean(col) => OwnedColumn::Boolean(col.to_vec()),
-            Column::TinyInt(col) => OwnedColumn::TinyInt(col.to_vec()),
-            Column::SmallInt(col) => OwnedColumn::SmallInt(col.to_vec()),
-            Column::Int(col) => OwnedColumn::Int(col.to_vec()),
-            Column::BigInt(col) => OwnedColumn::BigInt(col.to_vec()),
-            Column::VarChar((col, _)) => {
-                OwnedColumn::VarChar(col.iter().map(ToString::to_string).collect())
+            Column::Boolean(meta, col) => OwnedColumn::Boolean(*meta, col.to_vec()),
+            Column::TinyInt(meta, col) => OwnedColumn::TinyInt(*meta, col.to_vec()),
+            Column::SmallInt(meta, col) => OwnedColumn::SmallInt(*meta, col.to_vec()),
+            Column::Int(meta, col) => OwnedColumn::Int(*meta, col.to_vec()),
+            Column::BigInt(meta, col) => OwnedColumn::BigInt(*meta, col.to_vec()),
+            Column::VarChar(meta, (col, _)) => {
+                OwnedColumn::VarChar(*meta, col.iter().map(ToString::to_string).collect())
             }
-            Column::Int128(col) => OwnedColumn::Int128(col.to_vec()),
-            Column::Decimal75(precision, scale, col) => {
-                OwnedColumn::Decimal75(*precision, *scale, col.to_vec())
+            Column::Int128(meta, col) => OwnedColumn::Int128(*meta, col.to_vec()),
+            Column::Decimal75(meta, precision, scale, col) => {
+                OwnedColumn::Decimal75(*meta, *precision, *scale, col.to_vec())
             }
-            Column::Scalar(col) => OwnedColumn::Scalar(col.to_vec()),
-            Column::TimestampTZ(tu, tz, col) => OwnedColumn::TimestampTZ(*tu, *tz, col.to_vec()),
+            Column::Scalar(meta, col) => OwnedColumn::Scalar(*meta, col.to_vec()),
+            Column::TimestampTZ(meta, tu, tz, col) =>
+                OwnedColumn::TimestampTZ(*meta, *tu, *tz, col.to_vec()),
         }
     }
 }
@@ -338,16 +347,16 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
         .iter()
         .map(|(col, direction)| {
             let ordering = match col {
-                OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
-                OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
-                OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
-                OwnedColumn::Int(col) => col[i].cmp(&col[j]),
-                OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
+                OwnedColumn::Boolean(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::TinyInt(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::SmallInt(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::Int(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::BigInt(_, col) | OwnedColumn::TimestampTZ(_, _, _, col) => {
                     col[i].cmp(&col[j])
                 }
-                OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
-                OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
-                OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
+                OwnedColumn::Int128(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::Decimal75(_, _, _, col) | OwnedColumn::Scalar(_, col) => col[i].cmp(&col[j]),
+                OwnedColumn::VarChar(_, col) => col[i].cmp(&col[j]),
             };
             match direction {
                 OrderByDirection::Asc => ordering,

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -19,31 +19,32 @@ use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
 };
+use crate::base::database::column::ColumnTypeAssociatedData;
 
 #[derive(Debug, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 /// Supported types for [`OwnedColumn`]
 pub enum OwnedColumn<S: Scalar> {
     /// Boolean columns
-    Boolean(Vec<bool>),
+    Boolean(ColumnTypeAssociatedData, Vec<bool>),
     /// i8 columns
-    TinyInt(Vec<i8>),
+    TinyInt(ColumnTypeAssociatedData, Vec<i8>),
     /// i16 columns
-    SmallInt(Vec<i16>),
+    SmallInt(ColumnTypeAssociatedData, Vec<i16>),
     /// i32 columns
-    Int(Vec<i32>),
+    Int(ColumnTypeAssociatedData, Vec<i32>),
     /// i64 columns
-    BigInt(Vec<i64>),
+    BigInt(ColumnTypeAssociatedData, Vec<i64>),
     /// String columns
-    VarChar(Vec<String>),
+    VarChar(ColumnTypeAssociatedData, Vec<String>),
     /// i128 columns
-    Int128(Vec<i128>),
+    Int128(ColumnTypeAssociatedData, Vec<i128>),
     /// Decimal columns
-    Decimal75(Precision, i8, Vec<S>),
+    Decimal75(ColumnTypeAssociatedData, Precision, i8, Vec<S>),
     /// Scalar columns
-    Scalar(Vec<S>),
+    Scalar(ColumnTypeAssociatedData, Vec<S>),
     /// Timestamp columns
-    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, Vec<i64>),
+    TimestampTZ(ColumnTypeAssociatedData, PoSQLTimeUnit, PoSQLTimeZone, Vec<i64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -3,8 +3,8 @@
 /// converting to the final result in either Arrow format or JSON.
 /// This is the analog of an arrow Array.
 use super::{Column, ColumnType, OwnedColumnError, OwnedColumnResult};
-use crate::base::database::column::ColumnTypeAssociatedData;
 use crate::base::{
+    database::column::ColumnTypeAssociatedData,
     math::{
         decimal::Precision,
         permutation::{Permutation, PermutationError},

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -24,7 +24,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             Self::Boolean(_, values) => Ok(Self::Boolean(
                 ColumnTypeAssociatedData::NOT_NULLABLE,
-                slice_not(values)
+                slice_not(values),
             )),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
                 operator: UnaryOperator::Not,
@@ -42,7 +42,9 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::Boolean(meta, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(*meta, slice_and(lhs, rhs))),
+            (Self::Boolean(meta, lhs), Self::Boolean(_, rhs)) => {
+                Ok(Self::Boolean(*meta, slice_and(lhs, rhs)))
+            }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::And,
                 left_type: self.column_type(),
@@ -60,7 +62,10 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_or(lhs, rhs))),
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_or(lhs, rhs),
+            )),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Or,
                 left_type: self.column_type(),
@@ -78,171 +83,224 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::Int(_, rhs)) =>
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
-            }
-            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
+                ),
+            )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
-                    lhs_values,
-                    rhs_values,
-                    self.column_type(),
-                    rhs.column_type(),
-                )))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    eq_decimal_columns(
+                        lhs_values,
+                        rhs_values,
+                        self.column_type(),
+                        rhs.column_type(),
+                    ),
+                ))
             }
-            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) =>
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) =>
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
-            (Self::VarChar(_, lhs), Self::VarChar(_, rhs)) =>
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
+            (Self::VarChar(_, lhs), Self::VarChar(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_eq(lhs, rhs),
+            )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement equality check for TimeStampTZ")
             }
@@ -263,166 +321,245 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
-            }
-            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
             (Self::Int128(_, lhs), Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
             }
             (Self::Int128(_, lhs), Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
             }
             (Self::Int128(_, lhs), Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
             }
             (Self::Int128(_, lhs), Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
             }
-            (Self::Int128(_, lhs), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::Int128(_, lhs), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    slice_le(lhs, rhs),
+                ))
+            }
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (
+                Self::Decimal75(.., lhs_values),
+                Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+            ) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+                ),
+            )),
+            (
+                Self::Decimal75(.., lhs_values),
+                Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+            ) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+                ),
+            )),
+            (
+                Self::Decimal75(.., lhs_values),
+                Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+            ) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+                ),
+            )),
+            (
+                Self::Decimal75(.., lhs_values),
+                Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+            ) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+                ),
+            )),
+            (
+                Self::Decimal75(.., lhs_values),
+                Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+            ) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
+                ),
+            )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
-                    lhs_values,
-                    rhs_values,
-                    self.column_type(),
-                    rhs.column_type(),
-                )))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    le_decimal_columns(
+                        lhs_values,
+                        rhs_values,
+                        self.column_type(),
+                        rhs.column_type(),
+                    ),
+                ))
             }
-            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
-            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le(lhs, rhs),
+            )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }
@@ -443,171 +580,220 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
-            }
-            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge_with_casting(lhs, rhs),
+            )),
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::Int(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
-            }
-            (Self::Int128(_, lhs), Self::Int128(_, rhs)) =>
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_le_with_casting(rhs, lhs),
+            )),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
-                )))
-            }
+                ),
+            )),
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
-
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
-
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
-            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
-
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
+                ),
+            )),
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
-                )))
-            }
+                ),
+            )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
-
-                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
-                    lhs_values,
-                    rhs_values,
-                    self.column_type(),
-                    rhs.column_type(),
-                )))
+                Ok(Self::Boolean(
+                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ge_decimal_columns(
+                        lhs_values,
+                        rhs_values,
+                        self.column_type(),
+                        rhs.column_type(),
+                    ),
+                ))
             }
-            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
-            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_ge(lhs, rhs),
+            )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }
@@ -688,7 +874,9 @@ impl<S: Scalar> Add for OwnedColumn<S> {
             (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Int(meta, try_add_slices(lhs, rhs)?)),
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_add_slices(lhs, rhs)?))
+            }
             (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
@@ -714,7 +902,9 @@ impl<S: Scalar> Add for OwnedColumn<S> {
             (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(meta, try_add_slices(lhs, rhs)?)),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices(lhs, rhs)?))
+            }
             (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
@@ -740,7 +930,9 @@ impl<S: Scalar> Add for OwnedColumn<S> {
             (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::Int128(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(meta, try_add_slices(lhs, rhs)?)),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices(lhs, rhs)?))
+            }
             (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
@@ -826,22 +1018,25 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::TinyInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -851,22 +1046,25 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::SmallInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -876,20 +1074,24 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_subtract_slices(lhs, rhs)?)),
-            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -899,22 +1101,26 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -924,22 +1130,26 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_subtract_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -949,7 +1159,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -958,7 +1168,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -967,7 +1177,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -976,7 +1186,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -985,7 +1195,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1024,22 +1234,25 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::TinyInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1049,22 +1262,25 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::SmallInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1074,20 +1290,24 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_multiply_slices(lhs, rhs)?)),
-            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1097,22 +1317,26 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1122,22 +1346,26 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_multiply_slices_with_casting(rhs, lhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1147,7 +1375,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1156,7 +1384,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1165,7 +1393,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1174,7 +1402,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1183,7 +1411,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1222,22 +1450,23 @@ impl<S: Scalar> Div for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::TinyInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
-            }
-            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_divide_slices_left_upcast(lhs, rhs)?,
+            )),
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1247,22 +1476,23 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::SmallInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::SmallInt(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::SmallInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
                 Ok(Self::Int(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1272,20 +1502,22 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
                 Ok(Self::Int(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_divide_slices(lhs, rhs)?)),
-            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_divide_slices(lhs, rhs)?))
+            }
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1295,22 +1527,25 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::BigInt(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => {
                 Ok(Self::BigInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1320,22 +1555,26 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
-                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
-                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
-            }
-            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Int128(
+                meta,
+                try_divide_slices_right_upcast(lhs, rhs)?,
+            )),
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => {
                 Ok(Self::Int128(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1345,7 +1584,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1354,7 +1593,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1363,7 +1602,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1372,7 +1611,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1381,7 +1620,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 )?;
                 Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -1530,25 +1769,28 @@ mod test {
         let result = lhs.element_wise_and(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, false, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, false, false]
+            ))
         );
 
         let result = lhs.element_wise_or(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, true, false]
+            ))
         );
 
         let result = lhs.element_wise_not();
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                false, true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![false, true, false, true]
+            ))
         );
     }
 
@@ -1561,9 +1803,10 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, false]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
@@ -1571,9 +1814,10 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, false]
+            ))
         );
 
         // Strings
@@ -1594,9 +1838,10 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         // Booleans
@@ -1605,49 +1850,69 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, false]
+            ))
         );
 
         // Decimals
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            3,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, false]
+            ))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, -2, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
 
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, -2, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
     }
 
@@ -1660,9 +1925,10 @@ mod test {
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         // Integers
@@ -1671,9 +1937,10 @@ mod test {
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
@@ -1681,49 +1948,69 @@ mod test {
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
 
         // Decimals
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            3,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            -1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                false, true, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![false, true, true]
+            ))
         );
 
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            -1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                false, true, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![false, true, true]
+            ))
         );
     }
 
@@ -1736,9 +2023,10 @@ mod test {
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
 
         // Integers
@@ -1747,9 +2035,10 @@ mod test {
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
@@ -1757,49 +2046,69 @@ mod test {
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         // Decimals
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            3,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, false, true
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, false, true]
+            ))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            -1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
 
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
         let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, -20, 3]);
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            -1,
+            lhs_scalars,
+        );
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
-                true, true, false
-            ]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(
+                meta,
+                vec![true, true, false]
+            ))
         );
     }
 
@@ -1902,11 +2211,14 @@ mod test {
                 .map(ToString::to_string)
                 .collect(),
         );
-        let rhs = OwnedColumn::<Curve25519Scalar>::Scalar(meta, vec![
-            Curve25519Scalar::from(1),
-            Curve25519Scalar::from(2),
-            Curve25519Scalar::from(3),
-        ]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Scalar(
+            meta,
+            vec![
+                Curve25519Scalar::from(1),
+                Curve25519Scalar::from(2),
+                Curve25519Scalar::from(3),
+            ],
+        );
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
             result,
@@ -1941,7 +2253,10 @@ mod test {
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![2_i8, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(
+                meta,
+                vec![2_i8, 4, 6]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1_i16, 2, 3]);
@@ -1949,7 +2264,10 @@ mod test {
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![2_i16, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::SmallInt(
+                meta,
+                vec![2_i16, 4, 6]
+            ))
         );
 
         // lhs and rhs have different precisions
@@ -1958,7 +2276,10 @@ mod test {
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int(meta, vec![2_i32, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int(
+                meta,
+                vec![2_i32, 4, 6]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 3]);
@@ -1966,7 +2287,10 @@ mod test {
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![2_i128, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(
+                meta,
+                vec![2_i128, 4, 6]
+            ))
         );
     }
 
@@ -1976,10 +2300,18 @@ mod test {
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [2, 4, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -1995,10 +2327,18 @@ mod test {
         // lhs and rhs have different precisions and scales
         let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(51).unwrap(), 3, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(51).unwrap(),
+            3,
+            rhs_scalars,
+        );
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [11, 22, 33].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2014,8 +2354,12 @@ mod test {
         // lhs is integer and rhs is decimal
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [101, 202, 303].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2030,8 +2374,12 @@ mod test {
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [101, 202, 303].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2054,7 +2402,10 @@ mod test {
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![3_i8, 3, -1]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(
+                meta,
+                vec![3_i8, 3, -1]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4_i32, 5, 2]);
@@ -2062,7 +2413,10 @@ mod test {
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 3, -1]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int(
+                meta,
+                vec![3_i32, 3, -1]
+            ))
         );
 
         // lhs and rhs have different precisions
@@ -2071,7 +2425,10 @@ mod test {
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![3_i64, 3, -3]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(
+                meta,
+                vec![3_i64, 3, -3]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
@@ -2079,7 +2436,10 @@ mod test {
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![2_i64, 0, -2]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(
+                meta,
+                vec![2_i64, 0, -2]
+            ))
         );
     }
 
@@ -2089,10 +2449,18 @@ mod test {
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [3, 3, -1].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2108,10 +2476,18 @@ mod test {
         // lhs and rhs have different precisions and scales
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(25).unwrap(), 2, lhs_scalars);
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(51).unwrap(), 3, rhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(25).unwrap(),
+            2,
+            lhs_scalars,
+        );
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(51).unwrap(),
+            3,
+            rhs_scalars,
+        );
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [39, 48, 17].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2127,8 +2503,12 @@ mod test {
         // lhs is integer and rhs is decimal
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [399, 498, 197].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2143,8 +2523,12 @@ mod test {
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [399, 498, 197].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2167,7 +2551,10 @@ mod test {
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 10, -6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(
+                meta,
+                vec![4_i8, 10, -6]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 5, -2]);
@@ -2175,7 +2562,10 @@ mod test {
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 10, -6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(
+                meta,
+                vec![4_i64, 10, -6]
+            ))
         );
 
         // lhs and rhs have different precisions
@@ -2184,7 +2574,10 @@ mod test {
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 4, 15]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(
+                meta,
+                vec![3_i128, 4, 15]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
@@ -2192,7 +2585,10 @@ mod test {
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 4, 15]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(
+                meta,
+                vec![3_i128, 4, 15]
+            ))
         );
     }
 
@@ -2201,11 +2597,19 @@ mod test {
         let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [-4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2221,8 +2625,12 @@ mod test {
         // lhs is integer and rhs is decimal
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2237,8 +2645,12 @@ mod test {
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
@@ -2261,7 +2673,10 @@ mod test {
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 2, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(
+                meta,
+                vec![4_i8, 2, 0]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 5, -2]);
@@ -2269,7 +2684,10 @@ mod test {
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 2, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(
+                meta,
+                vec![4_i64, 2, 0]
+            ))
         );
 
         // lhs and rhs have different precisions
@@ -2278,7 +2696,10 @@ mod test {
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 1, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(
+                meta,
+                vec![3_i128, 1, 0]
+            ))
         );
 
         let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
@@ -2286,7 +2707,10 @@ mod test {
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 1, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(
+                meta,
+                vec![3_i128, 1, 0]
+            ))
         );
     }
 
@@ -2295,11 +2719,19 @@ mod test {
         let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 3].iter().map(Curve25519Scalar::from).collect();
-        let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            lhs_scalars,
+        );
         let rhs_scalars = [-1, 2, 4].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(5).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000_i128, 250_000_000, 75_000_000]
             .iter()
@@ -2318,8 +2750,12 @@ mod test {
         // lhs is integer and rhs is decimal
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 3]);
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(3).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(3).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000, 250_000_000, 100_000_000]
             .iter()
@@ -2337,8 +2773,12 @@ mod test {
 
         let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![4, 5, 3]);
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
-        let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(3).unwrap(), 2, rhs_scalars);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
+            meta,
+            Precision::new(3).unwrap(),
+            2,
+            rhs_scalars,
+        );
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000, 250_000_000, 100_000_000]
             .iter()

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -22,9 +22,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
     pub fn element_wise_not(&self) -> ColumnOperationResult<Self> {
         match self {
-            Self::Boolean(_, values) => {
-                Ok(Self::Boolean(ColumnNullability::NotNullable, slice_not(values)))
-            }
+            Self::Boolean(_, values) => Ok(Self::Boolean(
+                ColumnNullability::NotNullable,
+                slice_not(values),
+            )),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
                 operator: UnaryOperator::Not,
                 operand_type: self.column_type(),
@@ -440,18 +441,30 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
 
-            (Self::Int128(_, lhs), Self::TinyInt(ColumnNullability::NotNullable, rhs)) => Ok(
-                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
-            ),
-            (Self::Int128(_, lhs), Self::SmallInt(ColumnNullability::NotNullable, rhs)) => Ok(
-                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
-            ),
-            (Self::Int128(_, lhs), Self::Int(ColumnNullability::NotNullable, rhs)) => Ok(
-                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
-            ),
-            (Self::Int128(_, lhs), Self::BigInt(ColumnNullability::NotNullable, rhs)) => Ok(
-                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
-            ),
+            (Self::Int128(_, lhs), Self::TinyInt(ColumnNullability::NotNullable, rhs)) => {
+                Ok(Self::Boolean(
+                    ColumnNullability::NotNullable,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
+            }
+            (Self::Int128(_, lhs), Self::SmallInt(ColumnNullability::NotNullable, rhs)) => {
+                Ok(Self::Boolean(
+                    ColumnNullability::NotNullable,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
+            }
+            (Self::Int128(_, lhs), Self::Int(ColumnNullability::NotNullable, rhs)) => {
+                Ok(Self::Boolean(
+                    ColumnNullability::NotNullable,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
+            }
+            (Self::Int128(_, lhs), Self::BigInt(ColumnNullability::NotNullable, rhs)) => {
+                Ok(Self::Boolean(
+                    ColumnNullability::NotNullable,
+                    slice_ge_with_casting(rhs, lhs),
+                ))
+            }
             (Self::Int128(_, lhs), Self::Int128(ColumnNullability::NotNullable, rhs)) => Ok(
                 Self::Boolean(ColumnNullability::NotNullable, slice_le(lhs, rhs)),
             ),

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -1,4 +1,4 @@
-use super::{ColumnOperationError, ColumnOperationResult};
+use super::{ColumnOperationError, ColumnOperationResult, ColumnTypeAssociatedData};
 use crate::base::{
     database::{
         column_operation::{
@@ -22,7 +22,10 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
     pub fn element_wise_not(&self) -> ColumnOperationResult<Self> {
         match self {
-            Self::Boolean(values) => Ok(Self::Boolean(slice_not(values))),
+            Self::Boolean(_, values) => Ok(Self::Boolean(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                slice_not(values)
+            )),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
                 operator: UnaryOperator::Not,
                 operand_type: self.column_type(),
@@ -39,7 +42,7 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_and(lhs, rhs))),
+            (Self::Boolean(meta, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(*meta, slice_and(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::And,
                 left_type: self.column_type(),
@@ -57,7 +60,7 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_or(lhs, rhs))),
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_or(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Or,
                 left_type: self.column_type(),
@@ -75,21 +78,21 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -97,21 +100,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -119,21 +122,22 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) =>
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -141,21 +145,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(lhs, rhs)))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -163,21 +167,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -185,58 +189,61 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(eq_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, eq_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::VarChar(lhs), Self::VarChar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
-            (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) =>
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) =>
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::VarChar(_, lhs), Self::VarChar(_, rhs)) =>
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_eq(lhs, rhs))),
+            (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement equality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -256,21 +263,21 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -278,21 +285,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -300,21 +307,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -322,21 +329,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(lhs, rhs)))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -344,21 +351,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Int128(_, lhs), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -366,57 +373,57 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
-            (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le(lhs, rhs))),
+            (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -436,21 +443,21 @@ impl<S: Scalar> OwnedColumn<S> {
             });
         }
         match (self, rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -458,21 +465,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -480,21 +487,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -502,21 +509,21 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge_with_casting(lhs, rhs)))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -524,21 +531,22 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) =>
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
@@ -546,57 +554,61 @@ impl<S: Scalar> OwnedColumn<S> {
                 )))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
+
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
+
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
-                Ok(Self::Boolean(le_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
+
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, le_decimal_columns(
                     rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
                 )))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
-                Ok(Self::Boolean(ge_decimal_columns(
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
+
+                Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, ge_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
-            (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
+            (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, slice_ge(lhs, rhs))),
+            (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -612,6 +624,7 @@ impl<S: Scalar> Add for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn add(self, rhs: Self) -> Self::Output {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -619,178 +632,178 @@ impl<S: Scalar> Add for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::TinyInt(try_add_slices(lhs, rhs)?))
+            (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::TinyInt(meta, try_add_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::SmallInt(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::SmallInt(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::SmallInt(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_add_slices(lhs, rhs)?))
+            (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::SmallInt(meta, try_add_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Int(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Int(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(try_add_slices(lhs, rhs)?)),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Int(meta, try_add_slices(lhs, rhs)?)),
+            (Self::Int(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::Int(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::BigInt(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::BigInt(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::BigInt(try_add_slices(lhs, rhs)?)),
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(lhs, rhs)?))
+            (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::BigInt(meta, try_add_slices(lhs, rhs)?)),
+            (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(lhs, rhs)?))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_, lhs), Self::Int(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Int128(try_add_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => {
+                Ok(Self::Int128(meta, try_add_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Int128(try_add_slices(lhs, rhs)?)),
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Int128(meta, try_add_slices(lhs, rhs)?)),
+            (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_add_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Add,
@@ -805,6 +818,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn sub(self, rhs: Self) -> Self::Output {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -812,182 +826,182 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::TinyInt(try_subtract_slices(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::TinyInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::SmallInt(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_subtract_slices(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(try_subtract_slices(lhs, rhs)?)),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_subtract_slices(lhs, rhs)?)),
+            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_subtract_slices(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_left_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_subtract_slices(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_subtract_slices(lhs, rhs)?))
             }
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_subtract_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Subtract,
@@ -1002,6 +1016,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn mul(self, rhs: Self) -> Self::Output {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1009,182 +1024,182 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::TinyInt(try_multiply_slices(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::TinyInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::SmallInt(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_multiply_slices(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(try_multiply_slices(lhs, rhs)?)),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_multiply_slices(lhs, rhs)?)),
+            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_multiply_slices(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(lhs, rhs)?))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices_with_casting(rhs, lhs)?))
+            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices_with_casting(rhs, lhs)?))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_multiply_slices(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_multiply_slices(lhs, rhs)?))
             }
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_multiply_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Multiply,
@@ -1199,6 +1214,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn div(self, rhs: Self) -> Self::Output {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1206,182 +1222,182 @@ impl<S: Scalar> Div for OwnedColumn<S> {
             });
         }
         match (&self, &rhs) {
-            (Self::TinyInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::TinyInt(try_divide_slices(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::TinyInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::TinyInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::TinyInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::TinyInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::SmallInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::SmallInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::SmallInt(try_divide_slices(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::SmallInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::SmallInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::SmallInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(try_divide_slices(lhs, rhs)?)),
-            (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int(_,rhs)) => Ok(Self::Int(meta, try_divide_slices(lhs, rhs)?)),
+            (Self::Int(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::Int(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::BigInt(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::BigInt(try_divide_slices(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::BigInt(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            (Self::BigInt(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_left_upcast(lhs, rhs)?))
             }
-            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::BigInt(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Int128(lhs), Self::TinyInt(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::TinyInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::SmallInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::Int(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::BigInt(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices_right_upcast(lhs, rhs)?))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Int128(try_divide_slices(lhs, rhs)?))
+            (Self::Int128(_,lhs), Self::Int128(_,rhs)) => {
+                Ok(Self::Int128(meta, try_divide_slices(lhs, rhs)?))
             }
-            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Int128(_,lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
 
-            (Self::Decimal75(_, _, lhs_values), Self::TinyInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::TinyInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::SmallInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::BigInt(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Int128(_,rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
-            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+            (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
                     lhs_values,
                     rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )?;
-                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+                Ok(Self::Decimal75(meta, new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
                 operator: BinaryOperator::Division,
@@ -1399,8 +1415,9 @@ mod test {
 
     #[test]
     fn we_cannot_do_binary_operation_on_columns_with_different_lengths() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false]);
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false]);
 
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
@@ -1426,16 +1443,16 @@ mod test {
             Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2]);
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
             result,
             Err(ColumnOperationError::DifferentColumnLength { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 2]);
         let result = lhs.clone() + rhs.clone();
         assert!(matches!(
             result,
@@ -1463,8 +1480,9 @@ mod test {
 
     #[test]
     fn we_cannot_do_logical_operation_on_nonboolean_columns() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
             result,
@@ -1483,8 +1501,8 @@ mod test {
             Err(ColumnOperationError::UnaryOperationInvalidColumnType { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_and(&rhs);
         assert!(matches!(
             result,
@@ -1506,12 +1524,13 @@ mod test {
 
     #[test]
     fn we_can_do_logical_operation_on_boolean_columns() {
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true, false]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false, false]);
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true, false]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false, false]);
         let result = lhs.element_wise_and(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, false, false
             ]))
         );
@@ -1519,7 +1538,7 @@ mod test {
         let result = lhs.element_wise_or(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, true, false
             ]))
         );
@@ -1527,7 +1546,7 @@ mod test {
         let result = lhs.element_wise_not();
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 false, true, false, true
             ]))
         );
@@ -1535,35 +1554,38 @@ mod test {
 
     #[test]
     fn we_can_do_eq_operation() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, false
             ]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, false
             ]))
         );
 
         // Strings
         let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "Time"]
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
         );
         let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "time"]
                 .iter()
                 .map(ToString::to_string)
@@ -1572,18 +1594,18 @@ mod test {
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
 
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false]);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, false
             ]))
         );
@@ -1592,38 +1614,38 @@ mod test {
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, -3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, false
             ]))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, -2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, -2, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 1, lhs_scalars);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
 
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, -2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, -2, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 1, lhs_scalars);
         let result = lhs.element_wise_eq(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
@@ -1631,34 +1653,35 @@ mod test {
 
     #[test]
     fn we_can_do_le_operation_on_numeric_and_boolean_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false]);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
 
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
@@ -1667,38 +1690,38 @@ mod test {
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, -20, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, -20, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 false, true, true
             ]))
         );
 
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, -20, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, -20, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_le(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 false, true, true
             ]))
         );
@@ -1706,34 +1729,35 @@ mod test {
 
     #[test]
     fn we_can_do_ge_operation_on_numeric_and_boolean_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Booleans
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, true, false]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false]);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
 
         // Integers
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 3, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 3, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
@@ -1742,38 +1766,38 @@ mod test {
         let lhs_scalars = [10, 2, 30].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 24, -3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 3, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 3, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, false, true
             ]))
         );
 
         // Decimals and integers
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, -20, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, -20, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
 
         let lhs_scalars = [10, -2, -30].iter().map(Curve25519Scalar::from).collect();
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, -20, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, -20, 3]);
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), -1, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), -1, lhs_scalars);
         let result = lhs.element_wise_ge(&rhs);
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(vec![
+            Ok(OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![
                 true, true, false
             ]))
         );
@@ -1781,9 +1805,11 @@ mod test {
 
     #[test]
     fn we_cannot_do_comparison_on_columns_with_incompatible_types() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // Strings can't be compared with other types
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "Time"]
                 .iter()
                 .map(ToString::to_string)
@@ -1795,8 +1821,9 @@ mod test {
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
         let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "Time"]
                 .iter()
                 .map(ToString::to_string)
@@ -1821,16 +1848,16 @@ mod test {
         ));
 
         // Booleans can't be compared with other types
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert!(matches!(
             result,
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(vec![true, false, true]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_le(&rhs);
         assert!(matches!(
             result,
@@ -1839,12 +1866,14 @@ mod test {
 
         // Strings can not be <= or >= to each other
         let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "Time"]
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
         );
         let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "time"]
                 .iter()
                 .map(ToString::to_string)
@@ -1865,13 +1894,15 @@ mod test {
 
     #[test]
     fn we_cannot_do_arithmetic_on_nonnumeric_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
+            meta,
             ["Space", "and", "Time"]
                 .iter()
                 .map(ToString::to_string)
                 .collect(),
         );
-        let rhs = OwnedColumn::<Curve25519Scalar>::Scalar(vec![
+        let rhs = OwnedColumn::<Curve25519Scalar>::Scalar(meta, vec![
             Curve25519Scalar::from(1),
             Curve25519Scalar::from(2),
             Curve25519Scalar::from(3),
@@ -1903,55 +1934,58 @@ mod test {
 
     #[test]
     fn we_can_add_integer_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(vec![2_i8, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![2_i8, 4, 6]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1_i16, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![1_i16, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1_i16, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1_i16, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::SmallInt(vec![2_i16, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![2_i16, 4, 6]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1_i32, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1_i32, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int(vec![2_i32, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int(meta, vec![2_i32, 4, 6]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1_i32, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1_i32, 2, 3]);
         let result = lhs + rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![2_i128, 4, 6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![2_i128, 4, 6]))
         );
     }
 
     #[test]
     fn we_can_try_add_decimal_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [2, 4, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(6).unwrap(),
                 2,
                 expected_scalars
@@ -1962,14 +1996,15 @@ mod test {
         let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(51).unwrap(), 3, rhs_scalars);
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [11, 22, 33].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(52).unwrap(),
                 3,
                 expected_scalars
@@ -1977,30 +2012,32 @@ mod test {
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [101, 202, 303].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(6).unwrap(),
                 2,
                 expected_scalars
             )
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1, 2, 3]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs + rhs).unwrap();
         let expected_scalars = [101, 202, 303].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(13).unwrap(),
                 2,
                 expected_scalars
@@ -2010,55 +2047,58 @@ mod test {
 
     #[test]
     fn we_can_try_subtract_integer_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 5, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(vec![3_i8, 3, -1]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![3_i8, 3, -1]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4_i32, 5, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int(vec![1_i32, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4_i32, 5, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![1_i32, 2, 3]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 3, -1]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 3, -1]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 5, 2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, 2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, 2, 5]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![3_i64, 3, -3]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![3_i64, 3, -3]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, 2, 5]);
         let result = lhs - rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![2_i64, 0, -2]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![2_i64, 0, -2]))
         );
     }
 
     #[test]
     fn we_can_try_subtract_decimal_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [3, 3, -1].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(6).unwrap(),
                 2,
                 expected_scalars
@@ -2069,14 +2109,15 @@ mod test {
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(25).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(25).unwrap(), 2, lhs_scalars);
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(51).unwrap(), 3, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(51).unwrap(), 3, rhs_scalars);
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [39, 48, 17].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(52).unwrap(),
                 3,
                 expected_scalars
@@ -2084,30 +2125,32 @@ mod test {
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4, 5, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [399, 498, 197].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(6).unwrap(),
                 2,
                 expected_scalars
             )
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4, 5, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs - rhs).unwrap();
         let expected_scalars = [399, 498, 197].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(13).unwrap(),
                 2,
                 expected_scalars
@@ -2117,55 +2160,58 @@ mod test {
 
     #[test]
     fn we_can_try_multiply_integer_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, -2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 10, -6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 10, -6]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 5, -2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, 2, 3]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 10, -6]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 10, -6]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![3_i8, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![3_i8, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 5]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 4, 15]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 4, 15]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 5]);
         let result = lhs * rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 4, 15]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 4, 15]))
         );
     }
 
     #[test]
     fn we_can_try_multiply_decimal_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [-4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(11).unwrap(),
                 4,
                 expected_scalars
@@ -2173,30 +2219,32 @@ mod test {
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4, 5, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(9).unwrap(),
                 2,
                 expected_scalars
             )
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![4, 5, 2]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![4, 5, 2]);
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs * rhs).unwrap();
         let expected_scalars = [4, 10, 6].iter().map(Curve25519Scalar::from).collect();
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(16).unwrap(),
                 2,
                 expected_scalars
@@ -2206,50 +2254,52 @@ mod test {
 
     #[test]
     fn we_can_try_divide_integer_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs have the same precision
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![1_i8, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, -2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4_i8, 2, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 2, 0]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 5, -2]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 5, -2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![1_i64, 2, 3]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 2, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(meta, vec![4_i64, 2, 0]))
         );
 
         // lhs and rhs have different precisions
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![3_i8, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![3_i8, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 5]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 1, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 1, 0]))
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
-        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(meta, vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![1_i128, 2, 5]);
         let result = lhs / rhs;
         assert_eq!(
             result,
-            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 1, 0]))
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(meta, vec![3_i128, 1, 0]))
         );
     }
 
     #[test]
     fn we_can_try_divide_decimal_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, lhs_scalars);
         let rhs_scalars = [-1, 2, 4].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(5).unwrap(), 2, rhs_scalars);
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000_i128, 250_000_000, 75_000_000]
             .iter()
@@ -2258,6 +2308,7 @@ mod test {
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(13).unwrap(),
                 8,
                 expected_scalars
@@ -2265,10 +2316,10 @@ mod test {
         );
 
         // lhs is integer and rhs is decimal
-        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(vec![4, 5, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4, 5, 3]);
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(3).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(3).unwrap(), 2, rhs_scalars);
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000, 250_000_000, 100_000_000]
             .iter()
@@ -2277,16 +2328,17 @@ mod test {
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(11).unwrap(),
                 6,
                 expected_scalars
             )
         );
 
-        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![4, 5, 3]);
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![4, 5, 3]);
         let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs =
-            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(3).unwrap(), 2, rhs_scalars);
+            OwnedColumn::<Curve25519Scalar>::Decimal75(meta, Precision::new(3).unwrap(), 2, rhs_scalars);
         let result = (lhs / rhs).unwrap();
         let expected_scalars = [-400_000_000, 250_000_000, 100_000_000]
             .iter()
@@ -2295,6 +2347,7 @@ mod test {
         assert_eq!(
             result,
             OwnedColumn::<Curve25519Scalar>::Decimal75(
+                meta,
                 Precision::new(13).unwrap(),
                 6,
                 expected_scalars

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -1,4 +1,4 @@
-use super::{ColumnOperationError, ColumnOperationResult, ColumnTypeAssociatedData};
+use super::{ColumnNullability, ColumnOperationError, ColumnOperationResult};
 use crate::base::{
     database::{
         column_operation::{
@@ -22,10 +22,9 @@ impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
     pub fn element_wise_not(&self) -> ColumnOperationResult<Self> {
         match self {
-            Self::Boolean(_, values) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                slice_not(values),
-            )),
+            Self::Boolean(_, values) => {
+                Ok(Self::Boolean(ColumnNullability::NotNullable, slice_not(values)))
+            }
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
                 operator: UnaryOperator::Not,
                 operand_type: self.column_type(),
@@ -63,7 +62,7 @@ impl<S: Scalar> OwnedColumn<S> {
         }
         match (self, rhs) {
             (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_or(lhs, rhs),
             )),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -84,27 +83,27 @@ impl<S: Scalar> OwnedColumn<S> {
         }
         match (self, rhs) {
             (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -114,27 +113,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -144,27 +143,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -174,27 +173,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(lhs, rhs),
             )),
             (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -204,27 +203,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -234,7 +233,7 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -243,7 +242,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -252,7 +251,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -261,7 +260,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -270,7 +269,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 eq_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -280,7 +279,7 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     eq_decimal_columns(
                         lhs_values,
                         rhs_values,
@@ -290,15 +289,15 @@ impl<S: Scalar> OwnedColumn<S> {
                 ))
             }
             (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::VarChar(_, lhs), Self::VarChar(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_eq(lhs, rhs),
             )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
@@ -322,27 +321,27 @@ impl<S: Scalar> OwnedColumn<S> {
         }
         match (self, rhs) {
             (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -352,27 +351,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -382,27 +381,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -412,27 +411,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(lhs, rhs),
             )),
             (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -441,38 +440,23 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
 
-            (Self::Int128(_, lhs), Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    slice_ge_with_casting(rhs, lhs),
-                ))
-            }
-            (Self::Int128(_, lhs), Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    slice_ge_with_casting(rhs, lhs),
-                ))
-            }
-            (Self::Int128(_, lhs), Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    slice_ge_with_casting(rhs, lhs),
-                ))
-            }
-            (Self::Int128(_, lhs), Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    slice_ge_with_casting(rhs, lhs),
-                ))
-            }
-            (Self::Int128(_, lhs), Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs)) => {
-                Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
-                    slice_le(lhs, rhs),
-                ))
-            }
+            (Self::Int128(_, lhs), Self::TinyInt(ColumnNullability::NotNullable, rhs)) => Ok(
+                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
+            ),
+            (Self::Int128(_, lhs), Self::SmallInt(ColumnNullability::NotNullable, rhs)) => Ok(
+                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
+            ),
+            (Self::Int128(_, lhs), Self::Int(ColumnNullability::NotNullable, rhs)) => Ok(
+                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
+            ),
+            (Self::Int128(_, lhs), Self::BigInt(ColumnNullability::NotNullable, rhs)) => Ok(
+                Self::Boolean(ColumnNullability::NotNullable, slice_ge_with_casting(rhs, lhs)),
+            ),
+            (Self::Int128(_, lhs), Self::Int128(ColumnNullability::NotNullable, rhs)) => Ok(
+                Self::Boolean(ColumnNullability::NotNullable, slice_le(lhs, rhs)),
+            ),
             (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -483,9 +467,9 @@ impl<S: Scalar> OwnedColumn<S> {
 
             (
                 Self::Decimal75(.., lhs_values),
-                Self::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+                Self::TinyInt(ColumnNullability::NotNullable, rhs_values),
             ) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -495,9 +479,9 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (
                 Self::Decimal75(.., lhs_values),
-                Self::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+                Self::SmallInt(ColumnNullability::NotNullable, rhs_values),
             ) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -507,9 +491,9 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (
                 Self::Decimal75(.., lhs_values),
-                Self::Int(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+                Self::Int(ColumnNullability::NotNullable, rhs_values),
             ) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -519,9 +503,9 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (
                 Self::Decimal75(.., lhs_values),
-                Self::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+                Self::BigInt(ColumnNullability::NotNullable, rhs_values),
             ) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -531,9 +515,9 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (
                 Self::Decimal75(.., lhs_values),
-                Self::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, rhs_values),
+                Self::Int128(ColumnNullability::NotNullable, rhs_values),
             ) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -543,7 +527,7 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     le_decimal_columns(
                         lhs_values,
                         rhs_values,
@@ -553,11 +537,11 @@ impl<S: Scalar> OwnedColumn<S> {
                 ))
             }
             (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le(lhs, rhs),
             )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
@@ -581,27 +565,27 @@ impl<S: Scalar> OwnedColumn<S> {
         }
         match (self, rhs) {
             (Self::TinyInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::TinyInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -611,27 +595,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::SmallInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::SmallInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::SmallInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -641,27 +625,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Int(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::Int(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -671,27 +655,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::BigInt(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::BigInt(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::BigInt(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge_with_casting(lhs, rhs),
             )),
             (Self::BigInt(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -701,27 +685,27 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Int128(_, lhs), Self::TinyInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::SmallInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::Int(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::BigInt(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_le_with_casting(rhs, lhs),
             )),
             (Self::Int128(_, lhs), Self::Int128(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::Int128(_, lhs_values), Self::Decimal75(.., rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 ge_decimal_columns(
                     lhs_values,
                     rhs_values,
@@ -731,7 +715,7 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
 
             (Self::Decimal75(.., lhs_values), Self::TinyInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -740,7 +724,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::SmallInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -749,7 +733,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::Int(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -758,7 +742,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::BigInt(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -767,7 +751,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 ),
             )),
             (Self::Decimal75(.., lhs_values), Self::Int128(_, rhs_values)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 le_decimal_columns(
                     rhs_values,
                     lhs_values,
@@ -777,7 +761,7 @@ impl<S: Scalar> OwnedColumn<S> {
             )),
             (Self::Decimal75(.., lhs_values), Self::Decimal75(.., rhs_values)) => {
                 Ok(Self::Boolean(
-                    ColumnTypeAssociatedData::NOT_NULLABLE,
+                    ColumnNullability::NotNullable,
                     ge_decimal_columns(
                         lhs_values,
                         rhs_values,
@@ -787,11 +771,11 @@ impl<S: Scalar> OwnedColumn<S> {
                 ))
             }
             (Self::Boolean(_, lhs), Self::Boolean(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::Scalar(_, lhs), Self::Scalar(_, rhs)) => Ok(Self::Boolean(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 slice_ge(lhs, rhs),
             )),
             (Self::TimestampTZ(_, _, _, _), Self::TimestampTZ(_, _, _, _)) => {
@@ -810,7 +794,7 @@ impl<S: Scalar> Add for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1010,7 +994,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1226,7 +1210,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn mul(self, rhs: Self) -> Self::Output {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1442,7 +1426,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
     type Output = ColumnOperationResult<Self>;
 
     fn div(self, rhs: Self) -> Self::Output {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         if self.len() != rhs.len() {
             return Err(ColumnOperationError::DifferentColumnLength {
                 len_a: self.len(),
@@ -1654,7 +1638,7 @@ mod test {
 
     #[test]
     fn we_cannot_do_binary_operation_on_columns_with_different_lengths() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
         let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false]);
 
@@ -1719,7 +1703,7 @@ mod test {
 
     #[test]
     fn we_cannot_do_logical_operation_on_nonboolean_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let result = lhs.element_wise_and(&rhs);
@@ -1763,7 +1747,7 @@ mod test {
 
     #[test]
     fn we_can_do_logical_operation_on_boolean_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true, false]);
         let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false, false]);
         let result = lhs.element_wise_and(&rhs);
@@ -1796,7 +1780,7 @@ mod test {
 
     #[test]
     fn we_can_do_eq_operation() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Integers
         let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(meta, vec![1, 3, 2]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
@@ -1918,7 +1902,7 @@ mod test {
 
     #[test]
     fn we_can_do_le_operation_on_numeric_and_boolean_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Booleans
         let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
         let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false]);
@@ -2016,7 +2000,7 @@ mod test {
 
     #[test]
     fn we_can_do_ge_operation_on_numeric_and_boolean_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Booleans
         let lhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, false, true]);
         let rhs = OwnedColumn::<Curve25519Scalar>::Boolean(meta, vec![true, true, false]);
@@ -2114,7 +2098,7 @@ mod test {
 
     #[test]
     fn we_cannot_do_comparison_on_columns_with_incompatible_types() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // Strings can't be compared with other types
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1, 2, 3]);
         let rhs = OwnedColumn::<Curve25519Scalar>::VarChar(
@@ -2203,7 +2187,7 @@ mod test {
 
     #[test]
     fn we_cannot_do_arithmetic_on_nonnumeric_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let lhs = OwnedColumn::<Curve25519Scalar>::VarChar(
             meta,
             ["Space", "and", "Time"]
@@ -2246,7 +2230,7 @@ mod test {
 
     #[test]
     fn we_can_add_integer_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
@@ -2296,7 +2280,7 @@ mod test {
 
     #[test]
     fn we_can_try_add_decimal_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
@@ -2395,7 +2379,7 @@ mod test {
 
     #[test]
     fn we_can_try_subtract_integer_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, 2]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
@@ -2445,7 +2429,7 @@ mod test {
 
     #[test]
     fn we_can_try_subtract_decimal_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision and scale
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let rhs_scalars = [1, 2, 3].iter().map(Curve25519Scalar::from).collect();
@@ -2544,7 +2528,7 @@ mod test {
 
     #[test]
     fn we_can_try_multiply_integer_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, -2]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
@@ -2594,7 +2578,7 @@ mod test {
 
     #[test]
     fn we_can_try_multiply_decimal_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 2].iter().map(Curve25519Scalar::from).collect();
         let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(
@@ -2666,7 +2650,7 @@ mod test {
 
     #[test]
     fn we_can_try_divide_integer_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs have the same precision
         let lhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![4_i8, 5, -2]);
         let rhs = OwnedColumn::<Curve25519Scalar>::TinyInt(meta, vec![1_i8, 2, 3]);
@@ -2716,7 +2700,7 @@ mod test {
 
     #[test]
     fn we_can_try_divide_decimal_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         // lhs and rhs are both decimals
         let lhs_scalars = [4, 5, 3].iter().map(Curve25519Scalar::from).collect();
         let lhs = OwnedColumn::<Curve25519Scalar>::Decimal75(

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
@@ -10,7 +11,6 @@ use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
@@ -89,37 +89,44 @@ fn we_can_create_an_owned_table_with_data() {
     );
     table.insert(
         Identifier::try_new("varchar").unwrap(),
-        OwnedColumn::VarChar(meta, vec![
-            "0".to_string(),
-            "1".to_string(),
-            "2".to_string(),
-            "3".to_string(),
-            "4".to_string(),
-            "5".to_string(),
-            "6".to_string(),
-            "7".to_string(),
-            "8".to_string(),
-        ]),
+        OwnedColumn::VarChar(
+            meta,
+            vec![
+                "0".to_string(),
+                "1".to_string(),
+                "2".to_string(),
+                "3".to_string(),
+                "4".to_string(),
+                "5".to_string(),
+                "6".to_string(),
+                "7".to_string(),
+                "8".to_string(),
+            ],
+        ),
     );
     table.insert(
         Identifier::try_new("scalar").unwrap(),
-        OwnedColumn::Scalar(meta, vec![
-            DoryScalar::from(0),
-            1.into(),
-            2.into(),
-            3.into(),
-            4.into(),
-            5.into(),
-            6.into(),
-            7.into(),
-            8.into(),
-        ]),
+        OwnedColumn::Scalar(
+            meta,
+            vec![
+                DoryScalar::from(0),
+                1.into(),
+                2.into(),
+                3.into(),
+                4.into(),
+                5.into(),
+                6.into(),
+                7.into(),
+                8.into(),
+            ],
+        ),
     );
     table.insert(
         Identifier::try_new("boolean").unwrap(),
-        OwnedColumn::Boolean(meta, vec![
-            true, false, true, false, true, false, true, false, true,
-        ]),
+        OwnedColumn::Boolean(
+            meta,
+            vec![true, false, true, false, true, false, true, false, true],
+        ),
     );
     assert_eq!(owned_table.into_inner(), table);
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -1,8 +1,7 @@
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
-            OwnedTableError,
+            owned_table_utility::*, ColumnNullability, OwnedColumn, OwnedTable, OwnedTableError,
         },
         map::IndexMap,
         scalar::Curve25519Scalar,
@@ -21,7 +20,7 @@ fn we_can_create_an_owned_table_with_no_columns() {
 }
 #[test]
 fn we_can_create_an_empty_owned_table() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let owned_table = owned_table::<DoryScalar>([
         bigint("bigint", [0; 0]),
         int128("decimal", [0; 0]),
@@ -54,7 +53,7 @@ fn we_can_create_an_empty_owned_table() {
 }
 #[test]
 fn we_can_create_an_owned_table_with_data() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let owned_table = owned_table([
         bigint("bigint", [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
         int128("decimal", [0, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]),
@@ -190,7 +189,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
 }
 #[test]
 fn we_cannot_create_an_owned_table_with_differing_column_lengths() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     assert!(matches!(
         OwnedTable::<Curve25519Scalar>::try_from_iter([
             ("a".parse().unwrap(), OwnedColumn::BigInt(meta, vec![0])),

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -1,7 +1,9 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
-        database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
+        database::{
+            owned_table_utility::*, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+            OwnedTableError,
+        },
         map::IndexMap,
         scalar::Curve25519Scalar,
     },

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -10,6 +10,7 @@ use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
@@ -18,6 +19,7 @@ fn we_can_create_an_owned_table_with_no_columns() {
 }
 #[test]
 fn we_can_create_an_empty_owned_table() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let owned_table = owned_table::<DoryScalar>([
         bigint("bigint", [0; 0]),
         int128("decimal", [0; 0]),
@@ -28,28 +30,29 @@ fn we_can_create_an_empty_owned_table() {
     let mut table = IndexMap::default();
     table.insert(
         Identifier::try_new("bigint").unwrap(),
-        OwnedColumn::BigInt(vec![]),
+        OwnedColumn::BigInt(meta, vec![]),
     );
     table.insert(
         Identifier::try_new("decimal").unwrap(),
-        OwnedColumn::Int128(vec![]),
+        OwnedColumn::Int128(meta, vec![]),
     );
     table.insert(
         Identifier::try_new("varchar").unwrap(),
-        OwnedColumn::VarChar(vec![]),
+        OwnedColumn::VarChar(meta, vec![]),
     );
     table.insert(
         Identifier::try_new("scalar").unwrap(),
-        OwnedColumn::Scalar(vec![]),
+        OwnedColumn::Scalar(meta, vec![]),
     );
     table.insert(
         Identifier::try_new("boolean").unwrap(),
-        OwnedColumn::Boolean(vec![]),
+        OwnedColumn::Boolean(meta, vec![]),
     );
     assert_eq!(owned_table.into_inner(), table);
 }
 #[test]
 fn we_can_create_an_owned_table_with_data() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let owned_table = owned_table([
         bigint("bigint", [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
         int128("decimal", [0, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]),
@@ -70,6 +73,7 @@ fn we_can_create_an_owned_table_with_data() {
     table.insert(
         Identifier::try_new("time_stamp").unwrap(),
         OwnedColumn::TimestampTZ(
+            meta,
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
             [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX].into(),
@@ -77,15 +81,15 @@ fn we_can_create_an_owned_table_with_data() {
     );
     table.insert(
         Identifier::try_new("bigint").unwrap(),
-        OwnedColumn::BigInt(vec![0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
+        OwnedColumn::BigInt(meta, vec![0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
     );
     table.insert(
         Identifier::try_new("decimal").unwrap(),
-        OwnedColumn::Int128(vec![0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]),
+        OwnedColumn::Int128(meta, vec![0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]),
     );
     table.insert(
         Identifier::try_new("varchar").unwrap(),
-        OwnedColumn::VarChar(vec![
+        OwnedColumn::VarChar(meta, vec![
             "0".to_string(),
             "1".to_string(),
             "2".to_string(),
@@ -99,7 +103,7 @@ fn we_can_create_an_owned_table_with_data() {
     );
     table.insert(
         Identifier::try_new("scalar").unwrap(),
-        OwnedColumn::Scalar(vec![
+        OwnedColumn::Scalar(meta, vec![
             DoryScalar::from(0),
             1.into(),
             2.into(),
@@ -113,7 +117,7 @@ fn we_can_create_an_owned_table_with_data() {
     );
     table.insert(
         Identifier::try_new("boolean").unwrap(),
-        OwnedColumn::Boolean(vec![
+        OwnedColumn::Boolean(meta, vec![
             true, false, true, false, true, false, true, false, true,
         ]),
     );
@@ -177,10 +181,11 @@ fn we_get_inequality_between_tables_with_differing_data() {
 }
 #[test]
 fn we_cannot_create_an_owned_table_with_differing_column_lengths() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     assert!(matches!(
         OwnedTable::<Curve25519Scalar>::try_from_iter([
-            ("a".parse().unwrap(), OwnedColumn::BigInt(vec![0])),
-            ("b".parse().unwrap(), OwnedColumn::BigInt(vec![])),
+            ("a".parse().unwrap(), OwnedColumn::BigInt(meta, vec![0])),
+            ("b".parse().unwrap(), OwnedColumn::BigInt(meta, vec![])),
         ]),
         Err(OwnedTableError::ColumnLengthMismatch)
     ));

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -90,17 +90,17 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
             .get(&column.column_id())
             .unwrap()
         {
-            OwnedColumn::Boolean(meta,  col) => Column::Boolean(*meta, col),
-            OwnedColumn::TinyInt(meta,  col) => Column::TinyInt(*meta, col),
-            OwnedColumn::SmallInt(meta,  col) => Column::SmallInt(*meta, col),
-            OwnedColumn::Int(meta,  col) => Column::Int(*meta, col),
-            OwnedColumn::BigInt(meta,  col) => Column::BigInt(*meta, col),
-            OwnedColumn::Int128(meta,  col) => Column::Int128(*meta, col),
+            OwnedColumn::Boolean(meta, col) => Column::Boolean(*meta, col),
+            OwnedColumn::TinyInt(meta, col) => Column::TinyInt(*meta, col),
+            OwnedColumn::SmallInt(meta, col) => Column::SmallInt(*meta, col),
+            OwnedColumn::Int(meta, col) => Column::Int(*meta, col),
+            OwnedColumn::BigInt(meta, col) => Column::BigInt(*meta, col),
+            OwnedColumn::Int128(meta, col) => Column::Int128(*meta, col),
             OwnedColumn::Decimal75(meta, precision, scale, col) => {
                 Column::Decimal75(*meta, *precision, *scale, col)
             }
-            OwnedColumn::Scalar(meta,  col) => Column::Scalar(*meta, col),
-            OwnedColumn::VarChar(meta,  col) => {
+            OwnedColumn::Scalar(meta, col) => Column::Scalar(*meta, col),
+            OwnedColumn::VarChar(meta, col) => {
                 let col: &mut [&str] = self
                     .alloc
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
@@ -109,7 +109,9 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
                 Column::VarChar(*meta, (col, scals))
             }
-            OwnedColumn::TimestampTZ(meta, tu, tz, col) => Column::TimestampTZ(*meta, *tu, *tz, col),
+            OwnedColumn::TimestampTZ(meta, tu, tz, col) => {
+                Column::TimestampTZ(*meta, *tu, *tz, col)
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -90,26 +90,26 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
             .get(&column.column_id())
             .unwrap()
         {
-            OwnedColumn::Boolean(col) => Column::Boolean(col),
-            OwnedColumn::TinyInt(col) => Column::TinyInt(col),
-            OwnedColumn::SmallInt(col) => Column::SmallInt(col),
-            OwnedColumn::Int(col) => Column::Int(col),
-            OwnedColumn::BigInt(col) => Column::BigInt(col),
-            OwnedColumn::Int128(col) => Column::Int128(col),
-            OwnedColumn::Decimal75(precision, scale, col) => {
-                Column::Decimal75(*precision, *scale, col)
+            OwnedColumn::Boolean(meta,  col) => Column::Boolean(*meta, col),
+            OwnedColumn::TinyInt(meta,  col) => Column::TinyInt(*meta, col),
+            OwnedColumn::SmallInt(meta,  col) => Column::SmallInt(*meta, col),
+            OwnedColumn::Int(meta,  col) => Column::Int(*meta, col),
+            OwnedColumn::BigInt(meta,  col) => Column::BigInt(*meta, col),
+            OwnedColumn::Int128(meta,  col) => Column::Int128(*meta, col),
+            OwnedColumn::Decimal75(meta, precision, scale, col) => {
+                Column::Decimal75(*meta, *precision, *scale, col)
             }
-            OwnedColumn::Scalar(col) => Column::Scalar(col),
-            OwnedColumn::VarChar(col) => {
+            OwnedColumn::Scalar(meta,  col) => Column::Scalar(*meta, col),
+            OwnedColumn::VarChar(meta,  col) => {
                 let col: &mut [&str] = self
                     .alloc
                     .alloc_slice_fill_iter(col.iter().map(String::as_str));
                 let scals: &mut [_] = self
                     .alloc
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
-                Column::VarChar((col, scals))
+                Column::VarChar(*meta, (col, scals))
             }
-            OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
+            OwnedColumn::TimestampTZ(meta, tu, tz, col) => Column::TimestampTZ(*meta, *tu, *tz, col),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor, DataAccessor,
+    Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
     MetadataAccessor, OwnedTableTestAccessor, SchemaAccessor, TestAccessor,
 };
 use crate::base::{
@@ -31,7 +31,7 @@ fn we_can_query_the_length_of_a_table() {
 
 #[test]
 fn we_can_access_the_columns_of_a_table() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
@@ -142,7 +142,7 @@ fn we_can_access_the_columns_of_a_table() {
 
 #[test]
 fn we_can_access_the_commitments_of_table_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
@@ -186,7 +186,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
 #[test]
 fn we_can_access_the_type_of_table_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
@@ -239,11 +239,11 @@ fn we_can_access_schema_and_column_names() {
         vec![
             (
                 "a".parse().unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ColumnType::BigInt(ColumnNullability::NotNullable)
             ),
             (
                 "b".parse().unwrap(),
-                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ColumnType::VarChar(ColumnNullability::NotNullable)
             )
         ]
     );
@@ -252,7 +252,7 @@ fn we_can_access_schema_and_column_names() {
 
 #[test]
 fn we_can_correctly_update_offsets() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let mut accessor1 = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let table_ref = "sxt.test".parse().unwrap();
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -1,4 +1,7 @@
-use super::{Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTableTestAccessor, SchemaAccessor, TestAccessor};
+use super::{
+    Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor, DataAccessor,
+    MetadataAccessor, OwnedTableTestAccessor, SchemaAccessor, TestAccessor,
+};
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
     database::owned_table_utility::*,
@@ -70,7 +73,11 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "c128".parse().unwrap(), ColumnType::Int128(meta));
+    let column = ColumnRef::new(
+        table_ref_2,
+        "c128".parse().unwrap(),
+        ColumnType::Int128(meta),
+    );
     match accessor.get_column(column) {
         Column::Int128(_, col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
         _ => panic!("Invalid column type"),
@@ -81,7 +88,11 @@ fn we_can_access_the_columns_of_a_table() {
         .iter()
         .map(core::convert::Into::into)
         .collect();
-    let column = ColumnRef::new(table_ref_2, "varchar".parse().unwrap(), ColumnType::VarChar(meta));
+    let column = ColumnRef::new(
+        table_ref_2,
+        "varchar".parse().unwrap(),
+        ColumnType::VarChar(meta),
+    );
     match accessor.get_column(column) {
         Column::VarChar(_, (col, scals)) => {
             assert_eq!(col.to_vec(), col_slice);
@@ -90,7 +101,11 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "scalar".parse().unwrap(), ColumnType::Scalar(meta));
+    let column = ColumnRef::new(
+        table_ref_2,
+        "scalar".parse().unwrap(),
+        ColumnType::Scalar(meta),
+    );
     match accessor.get_column(column) {
         Column::Scalar(_, col) => assert_eq!(
             col.to_vec(),
@@ -104,7 +119,11 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "boolean".parse().unwrap(), ColumnType::Boolean(meta));
+    let column = ColumnRef::new(
+        table_ref_2,
+        "boolean".parse().unwrap(),
+        ColumnType::Boolean(meta),
+    );
     match accessor.get_column(column) {
         Column::Boolean(_, col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
         _ => panic!("Invalid column type"),
@@ -218,8 +237,14 @@ fn we_can_access_schema_and_column_names() {
     assert_eq!(
         accessor.lookup_schema(table_ref_1),
         vec![
-            ("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("b".parse().unwrap(), ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE))
+            (
+                "a".parse().unwrap(),
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ),
+            (
+                "b".parse().unwrap(),
+                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+            )
         ]
     );
     assert_eq!(accessor.get_column_names(table_ref_1), vec!["a", "b"]);

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -13,7 +13,7 @@
 //!     decimal75("f", 12, 1, [1, 2, 3]),
 //! ]);
 //! ```
-use super::{ColumnTypeAssociatedData, OwnedColumn, OwnedTable};
+use super::{ColumnNullability, OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
 use alloc::string::String;
 use core::ops::Deref;
@@ -66,7 +66,7 @@ pub fn tinyint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TinyInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -90,7 +90,7 @@ pub fn tinyint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TinyInt(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -114,7 +114,7 @@ pub fn smallint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::SmallInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -137,7 +137,7 @@ pub fn smallint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::SmallInt(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -161,7 +161,7 @@ pub fn int<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -184,7 +184,7 @@ pub fn int_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -207,7 +207,7 @@ pub fn bigint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -229,7 +229,7 @@ pub fn bigint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -254,7 +254,7 @@ pub fn boolean<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -278,7 +278,7 @@ pub fn boolean_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Boolean(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -303,7 +303,7 @@ pub fn int128<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int128(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -327,7 +327,7 @@ pub fn int128_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int128(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -352,7 +352,7 @@ pub fn scalar<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -377,7 +377,7 @@ pub fn scalar_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Scalar(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -402,7 +402,7 @@ pub fn varchar<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::VarChar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -427,7 +427,7 @@ pub fn varchar_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::VarChar(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             data.into_iter().map(Into::into).collect(),
         ),
     )
@@ -455,7 +455,7 @@ pub fn decimal75<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Decimal75(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             crate::base::math::decimal::Precision::new(precision).unwrap(),
             scale,
             data.into_iter().map(Into::into).collect(),
@@ -485,7 +485,7 @@ pub fn decimal75_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Decimal75(
-            ColumnTypeAssociatedData::NULLABLE,
+            ColumnNullability::Nullable,
             crate::base::math::decimal::Precision::new(precision).unwrap(),
             scale,
             data.into_iter().map(Into::into).collect(),
@@ -526,7 +526,7 @@ pub fn timestamptz<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TimestampTZ(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             time_unit,
             timezone,
             data.into_iter().collect(),
@@ -566,7 +566,7 @@ pub fn timestamptz_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TimestampTZ(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             time_unit,
             timezone,
             data.into_iter().collect(),

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -66,10 +66,11 @@ pub fn tinyint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TinyInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
-
 
 /// Creates a (Identifier, `OwnedColumn`) pair for a nullable tinyint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
@@ -89,7 +90,9 @@ pub fn tinyint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::TinyInt(
-            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -111,7 +114,9 @@ pub fn smallint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::SmallInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 /// Creates a `(Identifier, OwnedColumn)` pair for a smallint column.
@@ -132,7 +137,9 @@ pub fn smallint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::SmallInt(
-            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -154,7 +161,9 @@ pub fn int<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int(
-            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 /// Creates a `(Identifier, OwnedColumn)` pair for a nullable int column.
@@ -175,7 +184,9 @@ pub fn int_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int(
-            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -196,7 +207,9 @@ pub fn bigint<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 /// Creates a `(Identifier, OwnedColumn)` pair for a nullable bigint column.
@@ -216,7 +229,9 @@ pub fn bigint_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -239,7 +254,9 @@ pub fn boolean<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 /// Creates a `(Identifier, OwnedColumn)` pair for a nullable boolean column.
@@ -261,7 +278,9 @@ pub fn boolean_nullable<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Boolean(
-            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -283,7 +302,10 @@ pub fn int128<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Int128(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 /// Creates a `(Identifier, OwnedColumn)` pair for a nullable int128 column.
@@ -304,7 +326,10 @@ pub fn int128_nullable<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Int128(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Int128(
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -326,7 +351,10 @@ pub fn scalar<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -348,7 +376,10 @@ pub fn scalar_nullable<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Scalar(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Scalar(
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -370,7 +401,10 @@ pub fn varchar<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::VarChar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -392,7 +426,10 @@ pub fn varchar_nullable<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::VarChar(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+        OwnedColumn::VarChar(
+            ColumnTypeAssociatedData::NULLABLE,
+            data.into_iter().map(Into::into).collect(),
+        ),
     )
 }
 
@@ -425,7 +462,6 @@ pub fn decimal75<S: Scalar>(
         ),
     )
 }
-
 
 /// Creates a `(Identifier, OwnedColumn)` pair for a nullable decimal75 column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
@@ -493,7 +529,7 @@ pub fn timestamptz<S: Scalar>(
             ColumnTypeAssociatedData::NOT_NULLABLE,
             time_unit,
             timezone,
-            data.into_iter().collect()
+            data.into_iter().collect(),
         ),
     )
 }
@@ -533,7 +569,7 @@ pub fn timestamptz_nullable<S: Scalar>(
             ColumnTypeAssociatedData::NOT_NULLABLE,
             time_unit,
             timezone,
-            data.into_iter().collect()
+            data.into_iter().collect(),
         ),
     )
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -70,6 +70,29 @@ pub fn tinyint<S: Scalar>(
     )
 }
 
+
+/// Creates a (Identifier, `OwnedColumn`) pair for a nullable tinyint column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     tinyint_nullable("a", [1_i8, 2, 3]),
+/// ]);
+///```
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn tinyint_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i8>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::TinyInt(
+            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+
 /// Creates a `(Identifier, OwnedColumn)` pair for a smallint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
@@ -89,6 +112,27 @@ pub fn smallint<S: Scalar>(
         name.parse().unwrap(),
         OwnedColumn::SmallInt(
             ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+/// Creates a `(Identifier, OwnedColumn)` pair for a smallint column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```rust
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     smallint_nullable("a", [1_i16, 2, 3]),
+/// ]);
+/// ```
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn smallint_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i16>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::SmallInt(
+            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -113,6 +157,27 @@ pub fn int<S: Scalar>(
             ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable int column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```rust
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     int_nullable("a", [1, 2, 3]),
+/// ]);
+/// ```
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn int_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i32>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Int(
+            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
 
 /// Creates a `(Identifier, OwnedColumn)` pair for a bigint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
@@ -132,6 +197,26 @@ pub fn bigint<S: Scalar>(
         name.parse().unwrap(),
         OwnedColumn::BigInt(
             ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable bigint column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```rust
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     bigint_nullable("a", [1, 2, 3]),
+/// ]);
+/// ```
+#[allow(clippy::missing_panics_doc)]
+pub fn bigint_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i64>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::BigInt(
+            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -157,6 +242,28 @@ pub fn boolean<S: Scalar>(
             ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable boolean column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     boolean_nullable("a", [true, false, true]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn boolean_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<bool>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Boolean(
+            ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
 
 /// Creates a `(Identifier, OwnedColumn)` pair for a int128 column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
@@ -177,6 +284,27 @@ pub fn int128<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable int128 column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     int128_nullable("a", [1, 2, 3]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn int128_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i128>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Int128(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -202,6 +330,28 @@ pub fn scalar<S: Scalar>(
     )
 }
 
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable scalar column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     scalar_nullable("a", [1, 2, 3]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn scalar_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<S>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Scalar(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+
 /// Creates a `(Identifier, OwnedColumn)` pair for a varchar column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
@@ -221,6 +371,28 @@ pub fn varchar<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
+    )
+}
+
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable varchar column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     varchar_nullable("a", ["a", "b", "c"]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn varchar_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<String>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::VarChar(ColumnTypeAssociatedData::NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -254,6 +426,37 @@ pub fn decimal75<S: Scalar>(
     )
 }
 
+
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable decimal75 column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     decimal75_nullable("a", 12, 1, [1, 2, 3]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+/// - Panics if creating the `Precision` from the specified precision value fails.
+pub fn decimal75_nullable<S: Scalar>(
+    name: impl Deref<Target = str>,
+    precision: u8,
+    scale: i8,
+    data: impl IntoIterator<Item = impl Into<S>>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Decimal75(
+            ColumnTypeAssociatedData::NULLABLE,
+            crate::base::math::decimal::Precision::new(precision).unwrap(),
+            scale,
+            data.into_iter().map(Into::into).collect(),
+        ),
+    )
+}
+
 /// Creates a `(Identifier, OwnedColumn)` pair for a timestamp column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 ///
@@ -279,6 +482,46 @@ pub fn decimal75<S: Scalar>(
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn timestamptz<S: Scalar>(
+    name: impl Deref<Target = str>,
+    time_unit: PoSQLTimeUnit,
+    timezone: PoSQLTimeZone,
+    data: impl IntoIterator<Item = i64>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::TimestampTZ(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            time_unit,
+            timezone,
+            data.into_iter().collect()
+        ),
+    )
+}
+/// Creates a `(Identifier, OwnedColumn)` pair for a nullable timestamp column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+///
+/// # Parameters
+/// - `name`: The name of the column.
+/// - `time_unit`: The time unit of the timestamps.
+/// - `timezone`: The timezone for the timestamps.
+/// - `data`: The data for the column, provided as an iterator over `i64` values representing time since the unix epoch.
+///
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*,
+///     scalar::Curve25519Scalar,
+/// };
+/// use proof_of_sql_parser::{
+///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
+///
+/// let result = owned_table::<Curve25519Scalar>([
+///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, vec![1625072400, 1625076000, 1625079600]),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn timestamptz_nullable<S: Scalar>(
     name: impl Deref<Target = str>,
     time_unit: PoSQLTimeUnit,
     timezone: PoSQLTimeZone,

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -13,7 +13,7 @@
 //!     decimal75("f", 12, 1, [1, 2, 3]),
 //! ]);
 //! ```
-use super::{OwnedColumn, OwnedTable};
+use super::{ColumnTypeAssociatedData, OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
 use alloc::string::String;
 use core::ops::Deref;
@@ -65,7 +65,8 @@ pub fn tinyint<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::TinyInt(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::TinyInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -86,7 +87,8 @@ pub fn smallint<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::SmallInt(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::SmallInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -107,7 +109,8 @@ pub fn int<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Int(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Int(
+            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -127,7 +130,8 @@ pub fn bigint<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::BigInt(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -149,7 +153,8 @@ pub fn boolean<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Boolean(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -171,7 +176,7 @@ pub fn int128<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Int128(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -193,7 +198,7 @@ pub fn scalar<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Scalar(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -215,7 +220,7 @@ pub fn varchar<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::VarChar(data.into_iter().map(Into::into).collect()),
+        OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, data.into_iter().map(Into::into).collect()),
     )
 }
 
@@ -241,6 +246,7 @@ pub fn decimal75<S: Scalar>(
     (
         name.parse().unwrap(),
         OwnedColumn::Decimal75(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
             crate::base::math::decimal::Precision::new(precision).unwrap(),
             scale,
             data.into_iter().map(Into::into).collect(),
@@ -280,6 +286,11 @@ pub fn timestamptz<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::TimestampTZ(time_unit, timezone, data.into_iter().collect()),
+        OwnedColumn::TimestampTZ(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            time_unit,
+            timezone,
+            data.into_iter().collect()
+        ),
     )
 }

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -173,21 +173,36 @@ pub fn make_random_test_accessor_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::record_batch;
     use rand_core::SeedableRng;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_a_random_test_data() {
         let descriptor = RandomTestAccessorDescriptor::default();
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            ("a", ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("b", ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("c", ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("d", ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            (
+                "a",
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
+            (
+                "b",
+                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
+            (
+                "c",
+                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
+            (
+                "d",
+                ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
             ("e", ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("f", ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            (
+                "f",
+                ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
         ];
 
         let data1 = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
@@ -205,9 +220,18 @@ mod tests {
         };
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            ("b", ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("a", ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ("c", ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            (
+                "b",
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
+            (
+                "a",
+                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
+            (
+                "c",
+                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ),
         ];
         let data = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -173,7 +173,7 @@ pub fn make_random_test_accessor_data(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{base::database::ColumnTypeAssociatedData, record_batch};
+    use crate::{base::database::ColumnNullability, record_batch};
     use rand_core::SeedableRng;
 
     #[test]
@@ -181,27 +181,12 @@ mod tests {
         let descriptor = RandomTestAccessorDescriptor::default();
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            (
-                "a",
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            (
-                "b",
-                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            (
-                "c",
-                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            (
-                "d",
-                ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            ("e", ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            (
-                "f",
-                ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
+            ("a", ColumnType::BigInt(ColumnNullability::NotNullable)),
+            ("b", ColumnType::VarChar(ColumnNullability::NotNullable)),
+            ("c", ColumnType::Int128(ColumnNullability::NotNullable)),
+            ("d", ColumnType::SmallInt(ColumnNullability::NotNullable)),
+            ("e", ColumnType::Int(ColumnNullability::NotNullable)),
+            ("f", ColumnType::TinyInt(ColumnNullability::NotNullable)),
         ];
 
         let data1 = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
@@ -219,18 +204,9 @@ mod tests {
         };
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            (
-                "b",
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            (
-                "a",
-                ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
-            (
-                "c",
-                ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
-            ),
+            ("b", ColumnType::BigInt(ColumnNullability::NotNullable)),
+            ("a", ColumnType::VarChar(ColumnNullability::NotNullable)),
+            ("c", ColumnType::Int128(ColumnNullability::NotNullable)),
         ];
         let data = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -64,12 +64,12 @@ pub fn make_random_test_accessor_data(
         let values: Vec<i64> = dist.sample_iter(&mut *rng).take(n).collect();
 
         match col_type {
-            ColumnType::Boolean => {
+            ColumnType::Boolean(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Boolean, false));
                 let boolean_values: Vec<bool> = values.iter().map(|x| x % 2 != 0).collect();
                 columns.push(Arc::new(BooleanArray::from(boolean_values)));
             }
-            ColumnType::TinyInt => {
+            ColumnType::TinyInt(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Int8, false));
                 let values: Vec<i8> = values
                     .iter()
@@ -77,7 +77,7 @@ pub fn make_random_test_accessor_data(
                     .collect();
                 columns.push(Arc::new(Int8Array::from(values)));
             }
-            ColumnType::SmallInt => {
+            ColumnType::SmallInt(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Int16, false));
                 let values: Vec<i16> = values
                     .iter()
@@ -85,7 +85,7 @@ pub fn make_random_test_accessor_data(
                     .collect();
                 columns.push(Arc::new(Int16Array::from(values)));
             }
-            ColumnType::Int => {
+            ColumnType::Int(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Int32, false));
                 let values: Vec<i32> = values
                     .iter()
@@ -93,12 +93,12 @@ pub fn make_random_test_accessor_data(
                     .collect();
                 columns.push(Arc::new(Int32Array::from(values)));
             }
-            ColumnType::BigInt => {
+            ColumnType::BigInt(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Int64, false));
                 let values: Vec<i64> = values.clone();
                 columns.push(Arc::new(Int64Array::from(values)));
             }
-            ColumnType::Int128 => {
+            ColumnType::Int128(_) => {
                 column_fields.push(Field::new(*col_name, DataType::Decimal128(38, 0), false));
 
                 let values: Vec<i128> = values.iter().map(|x| i128::from(*x)).collect();
@@ -108,7 +108,7 @@ pub fn make_random_test_accessor_data(
                         .unwrap(),
                 ));
             }
-            ColumnType::Decimal75(precision, scale) => {
+            ColumnType::Decimal75(_, precision, scale) => {
                 column_fields.push(Field::new(
                     *col_name,
                     DataType::Decimal256(precision.value(), *scale),
@@ -122,7 +122,7 @@ pub fn make_random_test_accessor_data(
                         .unwrap(),
                 ));
             }
-            ColumnType::VarChar => {
+            ColumnType::VarChar(_) => {
                 let col = &values
                     .iter()
                     .map(|v| "s".to_owned() + &v.to_string()[..])
@@ -133,8 +133,8 @@ pub fn make_random_test_accessor_data(
 
                 columns.push(Arc::new(StringArray::from(col)));
             }
-            ColumnType::Scalar => unimplemented!("Scalar columns are not supported by arrow"),
-            ColumnType::TimestampTZ(tu, tz) => {
+            ColumnType::Scalar(_) => unimplemented!("Scalar columns are not supported by arrow"),
+            ColumnType::TimestampTZ(_, tu, tz) => {
                 column_fields.push(Field::new(
                     *col_name,
                     DataType::Timestamp(
@@ -175,18 +175,19 @@ mod tests {
     use super::*;
     use crate::record_batch;
     use rand_core::SeedableRng;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_construct_a_random_test_data() {
         let descriptor = RandomTestAccessorDescriptor::default();
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            ("a", ColumnType::BigInt),
-            ("b", ColumnType::VarChar),
-            ("c", ColumnType::Int128),
-            ("d", ColumnType::SmallInt),
-            ("e", ColumnType::Int),
-            ("f", ColumnType::TinyInt),
+            ("a", ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("b", ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("c", ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("d", ColumnType::SmallInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("e", ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("f", ColumnType::TinyInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
         ];
 
         let data1 = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
@@ -204,9 +205,9 @@ mod tests {
         };
         let mut rng = StdRng::from_seed([0u8; 32]);
         let cols = [
-            ("b", ColumnType::BigInt),
-            ("a", ColumnType::VarChar),
-            ("c", ColumnType::Int128),
+            ("b", ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("a", ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ("c", ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)),
         ];
         let data = make_random_test_accessor_data(&mut rng, &cols, &descriptor);
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -173,8 +173,7 @@ pub fn make_random_test_accessor_data(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
-    use crate::record_batch;
+    use crate::{base::database::ColumnTypeAssociatedData, record_batch};
     use rand_core::SeedableRng;
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -31,8 +31,8 @@ impl SchemaAccessor for TestSchemaAccessor {
 
 #[cfg(test)]
 mod tests {
-    use crate::base::database::ColumnTypeAssociatedData;
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::base::map::indexmap;
 
     fn sample_test_schema_accessor() -> TestSchemaAccessor {
@@ -98,13 +98,22 @@ mod tests {
         assert_eq!(
             accessor.lookup_schema(table1),
             vec![
-                ("col1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
-                ("col2".parse().unwrap(), ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
+                (
+                    "col1".parse().unwrap(),
+                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ),
+                (
+                    "col2".parse().unwrap(),
+                    ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ),
             ]
         );
         assert_eq!(
             accessor.lookup_schema(table2),
-            vec![("col1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),]
+            vec![(
+                "col1".parse().unwrap(),
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ),]
         );
         assert_eq!(accessor.lookup_schema(not_a_table), vec![]);
     }

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -32,18 +32,18 @@ impl SchemaAccessor for TestSchemaAccessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::ColumnTypeAssociatedData, map::indexmap};
+    use crate::base::{database::ColumnNullability, map::indexmap};
 
     fn sample_test_schema_accessor() -> TestSchemaAccessor {
         let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());
         let table2: TableRef = TableRef::new("schema.table2".parse().unwrap());
         TestSchemaAccessor::new(indexmap! {
             table1 => indexmap! {
-                "col1".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-                "col2".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+                "col1".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+                "col2".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
             },
             table2 => indexmap! {
-                "col1".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                "col1".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
             },
         })
     }
@@ -56,11 +56,11 @@ mod tests {
         let not_a_table: TableRef = TableRef::new("schema.not_a_table".parse().unwrap());
         assert_eq!(
             accessor.lookup_column(table1, "col1".parse().unwrap()),
-            Some(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
+            Some(ColumnType::BigInt(ColumnNullability::NotNullable))
         );
         assert_eq!(
             accessor.lookup_column(table1, "col2".parse().unwrap()),
-            Some(ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE))
+            Some(ColumnType::VarChar(ColumnNullability::NotNullable))
         );
         assert_eq!(
             accessor.lookup_column(table1, "not_a_col".parse().unwrap()),
@@ -68,7 +68,7 @@ mod tests {
         );
         assert_eq!(
             accessor.lookup_column(table2, "col1".parse().unwrap()),
-            Some(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
+            Some(ColumnType::BigInt(ColumnNullability::NotNullable))
         );
         assert_eq!(
             accessor.lookup_column(table2, "col2".parse().unwrap()),
@@ -99,11 +99,11 @@ mod tests {
             vec![
                 (
                     "col1".parse().unwrap(),
-                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                    ColumnType::BigInt(ColumnNullability::NotNullable)
                 ),
                 (
                     "col2".parse().unwrap(),
-                    ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)
+                    ColumnType::VarChar(ColumnNullability::NotNullable)
                 ),
             ]
         );
@@ -111,7 +111,7 @@ mod tests {
             accessor.lookup_schema(table2),
             vec![(
                 "col1".parse().unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ColumnType::BigInt(ColumnNullability::NotNullable)
             ),]
         );
         assert_eq!(accessor.lookup_schema(not_a_table), vec![]);

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -32,8 +32,7 @@ impl SchemaAccessor for TestSchemaAccessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
-    use crate::base::map::indexmap;
+    use crate::base::{database::ColumnTypeAssociatedData, map::indexmap};
 
     fn sample_test_schema_accessor() -> TestSchemaAccessor {
         let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -31,6 +31,7 @@ impl SchemaAccessor for TestSchemaAccessor {
 
 #[cfg(test)]
 mod tests {
+    use crate::base::database::ColumnTypeAssociatedData;
     use super::*;
     use crate::base::map::indexmap;
 
@@ -39,11 +40,11 @@ mod tests {
         let table2: TableRef = TableRef::new("schema.table2".parse().unwrap());
         TestSchemaAccessor::new(indexmap! {
             table1 => indexmap! {
-                "col1".parse().unwrap() => ColumnType::BigInt,
-                "col2".parse().unwrap() => ColumnType::VarChar,
+                "col1".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                "col2".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
             },
             table2 => indexmap! {
-                "col1".parse().unwrap() => ColumnType::BigInt,
+                "col1".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
             },
         })
     }
@@ -56,11 +57,11 @@ mod tests {
         let not_a_table: TableRef = TableRef::new("schema.not_a_table".parse().unwrap());
         assert_eq!(
             accessor.lookup_column(table1, "col1".parse().unwrap()),
-            Some(ColumnType::BigInt)
+            Some(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
         );
         assert_eq!(
             accessor.lookup_column(table1, "col2".parse().unwrap()),
-            Some(ColumnType::VarChar)
+            Some(ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE))
         );
         assert_eq!(
             accessor.lookup_column(table1, "not_a_col".parse().unwrap()),
@@ -68,7 +69,7 @@ mod tests {
         );
         assert_eq!(
             accessor.lookup_column(table2, "col1".parse().unwrap()),
-            Some(ColumnType::BigInt)
+            Some(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
         );
         assert_eq!(
             accessor.lookup_column(table2, "col2".parse().unwrap()),
@@ -97,13 +98,13 @@ mod tests {
         assert_eq!(
             accessor.lookup_schema(table1),
             vec![
-                ("col1".parse().unwrap(), ColumnType::BigInt),
-                ("col2".parse().unwrap(), ColumnType::VarChar),
+                ("col1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+                ("col2".parse().unwrap(), ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE)),
             ]
         );
         assert_eq!(
             accessor.lookup_schema(table2),
-            vec![("col1".parse().unwrap(), ColumnType::BigInt),]
+            vec![("col1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),]
         );
         assert_eq!(accessor.lookup_schema(not_a_table), vec![]);
     }

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -105,7 +105,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             }
             Column::TinyInt(_, c) => c.inner_product(evaluation_vec),
             Column::SmallInt(_, c) => c.inner_product(evaluation_vec),
-            Column::Int(_, c, ) => c.inner_product(evaluation_vec),
+            Column::Int(_, c) => c.inner_product(evaluation_vec),
             Column::BigInt(_, c) | Column::TimestampTZ(.., c) => c.inner_product(evaluation_vec),
             Column::Int128(_, c) => c.inner_product(evaluation_vec),
         }
@@ -148,7 +148,9 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::TinyInt(_, c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(_, c) => MultilinearExtension::<S>::id(c),
             Column::Int(_, c) => MultilinearExtension::<S>::id(c),
-            Column::BigInt(_, c) | Column::TimestampTZ(_, _, _, c) => MultilinearExtension::<S>::id(c),
+            Column::BigInt(_, c) | Column::TimestampTZ(_, _, _, c) => {
+                MultilinearExtension::<S>::id(c)
+            }
             Column::Int128(_, c) => MultilinearExtension::<S>::id(c),
         }
     }

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -99,57 +99,57 @@ where
 impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
     fn inner_product(&self, evaluation_vec: &[S]) -> S {
         match self {
-            Column::Boolean(c) => c.inner_product(evaluation_vec),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+            Column::Boolean(_, c) => c.inner_product(evaluation_vec),
+            Column::Scalar(_, c) | Column::VarChar(_, (_, c)) | Column::Decimal75(.., c) => {
                 c.inner_product(evaluation_vec)
             }
-            Column::TinyInt(c) => c.inner_product(evaluation_vec),
-            Column::SmallInt(c) => c.inner_product(evaluation_vec),
-            Column::Int(c) => c.inner_product(evaluation_vec),
-            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.inner_product(evaluation_vec),
-            Column::Int128(c) => c.inner_product(evaluation_vec),
+            Column::TinyInt(_, c) => c.inner_product(evaluation_vec),
+            Column::SmallInt(_, c) => c.inner_product(evaluation_vec),
+            Column::Int(_, c, ) => c.inner_product(evaluation_vec),
+            Column::BigInt(_, c) | Column::TimestampTZ(.., c) => c.inner_product(evaluation_vec),
+            Column::Int128(_, c) => c.inner_product(evaluation_vec),
         }
     }
 
     fn mul_add(&self, res: &mut [S], multiplier: &S) {
         match self {
-            Column::Boolean(c) => c.mul_add(res, multiplier),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+            Column::Boolean(_, c) => c.mul_add(res, multiplier),
+            Column::Scalar(_, c) | Column::VarChar(_, (_, c)) | Column::Decimal75(.., c) => {
                 c.mul_add(res, multiplier);
             }
-            Column::TinyInt(c) => c.mul_add(res, multiplier),
-            Column::SmallInt(c) => c.mul_add(res, multiplier),
-            Column::Int(c) => c.mul_add(res, multiplier),
-            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.mul_add(res, multiplier),
-            Column::Int128(c) => c.mul_add(res, multiplier),
+            Column::TinyInt(_, c) => c.mul_add(res, multiplier),
+            Column::SmallInt(_, c) => c.mul_add(res, multiplier),
+            Column::Int(_, c) => c.mul_add(res, multiplier),
+            Column::BigInt(_, c) | Column::TimestampTZ(.., c) => c.mul_add(res, multiplier),
+            Column::Int128(_, c) => c.mul_add(res, multiplier),
         }
     }
 
     fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
         match self {
-            Column::Boolean(c) => c.to_sumcheck_term(num_vars),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+            Column::Boolean(_, c) => c.to_sumcheck_term(num_vars),
+            Column::Scalar(_, c) | Column::VarChar(_, (_, c)) | Column::Decimal75(.., c) => {
                 c.to_sumcheck_term(num_vars)
             }
-            Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
-            Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
-            Column::Int(c) => c.to_sumcheck_term(num_vars),
-            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.to_sumcheck_term(num_vars),
-            Column::Int128(c) => c.to_sumcheck_term(num_vars),
+            Column::TinyInt(_, c) => c.to_sumcheck_term(num_vars),
+            Column::SmallInt(_, c) => c.to_sumcheck_term(num_vars),
+            Column::Int(_, c) => c.to_sumcheck_term(num_vars),
+            Column::BigInt(_, c) | Column::TimestampTZ(.., c) => c.to_sumcheck_term(num_vars),
+            Column::Int128(_, c) => c.to_sumcheck_term(num_vars),
         }
     }
 
     fn id(&self) -> *const c_void {
         match self {
-            Column::Boolean(c) => MultilinearExtension::<S>::id(c),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+            Column::Boolean(_, c) => MultilinearExtension::<S>::id(c),
+            Column::Scalar(_, c) | Column::VarChar(_, (_, c)) | Column::Decimal75(_, _, _, c) => {
                 MultilinearExtension::<S>::id(c)
             }
-            Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
-            Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
-            Column::Int(c) => MultilinearExtension::<S>::id(c),
-            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => MultilinearExtension::<S>::id(c),
-            Column::Int128(c) => MultilinearExtension::<S>::id(c),
+            Column::TinyInt(_, c) => MultilinearExtension::<S>::id(c),
+            Column::SmallInt(_, c) => MultilinearExtension::<S>::id(c),
+            Column::Int(_, c) => MultilinearExtension::<S>::id(c),
+            Column::BigInt(_, c) | Column::TimestampTZ(_, _, _, c) => MultilinearExtension::<S>::id(c),
+            Column::Int128(_, c) => MultilinearExtension::<S>::id(c),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,5 +1,6 @@
 use super::MultilinearExtension;
 use crate::base::{database::Column, scalar::Curve25519Scalar};
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {
@@ -37,7 +38,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_column() {
-    let slice = Column::BigInt(&[2, 3, 4, 5, 6]);
+    let slice = Column::BigInt(ColumnTypeAssociatedData::default(), &[2, 3, 4, 5, 6]);
     let evaluation_vec: Vec<Curve25519Scalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,6 +1,8 @@
 use super::MultilinearExtension;
-use crate::base::database::ColumnTypeAssociatedData;
-use crate::base::{database::Column, scalar::Curve25519Scalar};
+use crate::base::{
+    database::{Column, ColumnTypeAssociatedData},
+    scalar::Curve25519Scalar,
+};
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,6 +1,6 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::Curve25519Scalar};
 use crate::base::database::ColumnTypeAssociatedData;
+use crate::base::{database::Column, scalar::Curve25519Scalar};
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,6 +1,6 @@
 use super::MultilinearExtension;
 use crate::base::{
-    database::{Column, ColumnTypeAssociatedData},
+    database::{Column, ColumnNullability},
     scalar::Curve25519Scalar,
 };
 
@@ -40,7 +40,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_column() {
-    let slice = Column::BigInt(ColumnTypeAssociatedData::default(), &[2, 3, 4, 5, 6]);
+    let slice = Column::BigInt(ColumnNullability::default(), &[2, 3, 4, 5, 6]);
     let evaluation_vec: Vec<Curve25519Scalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::{
         base::{
             commitment::{NumColumnsMismatch, VecCommitmentExt},
-            database::{Column, ColumnTypeAssociatedData, OwnedColumn},
+            database::{Column, ColumnNullability, OwnedColumn},
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
@@ -131,11 +131,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
-                column_a.to_vec(),
-            ),
-            OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, column_b.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(ColumnNullability::NotNullable, column_a.to_vec()),
+            OwnedColumn::VarChar(ColumnNullability::NotNullable, column_b.to_vec()),
         ];
 
         let commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
@@ -159,7 +156,7 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -210,7 +207,7 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -253,7 +250,7 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -311,7 +308,7 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -363,7 +360,7 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -412,7 +409,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -456,7 +453,7 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
-        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+        let meta = ColumnNullability::NotNullable;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -108,6 +108,7 @@ mod tests {
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
     use ark_ec::pairing::Pairing;
+    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_convert_from_columns() {
@@ -131,8 +132,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, column_a.to_vec()),
+            OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, column_b.to_vec()),
         ];
 
         let commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
@@ -156,6 +157,7 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -166,15 +168,15 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let mut commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
 
         let new_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
         ];
 
         commitments
@@ -206,6 +208,7 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -214,8 +217,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let mut commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
@@ -226,16 +229,16 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec())];
+        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec())];
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &setup),
             Err(NumColumnsMismatch)
         ));
 
         let new_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
-            OwnedColumn::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
+            OwnedColumn::BigInt(meta, column_a[3..].to_vec()),
         ];
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &setup),
@@ -245,6 +248,7 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -257,15 +261,15 @@ mod tests {
         let column_d = [78i64, 90, 1112];
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
         ];
 
         let mut commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
 
         let new_columns = vec![
-            OwnedColumn::<DoryScalar>::VarChar(column_c.to_vec()),
-            OwnedColumn::BigInt(column_d.to_vec()),
+            OwnedColumn::<DoryScalar>::VarChar(meta, column_c.to_vec()),
+            OwnedColumn::BigInt(meta, column_d.to_vec()),
         ];
 
         commitments.extend_columns_with_offset(&new_columns, 0, &setup);
@@ -302,6 +306,7 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -312,15 +317,15 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments_a = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
 
         let new_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
         ];
 
         let commitments_b =
@@ -353,6 +358,7 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -361,8 +367,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
@@ -375,7 +381,7 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec())];
+        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec())];
         let new_commitments =
             Vec::<DoryCommitment>::from_columns_with_offset(&new_columns, 3, &setup);
         assert!(matches!(
@@ -384,9 +390,9 @@ mod tests {
         ));
 
         let new_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[3..].to_vec()),
-            OwnedColumn::VarChar(column_b[3..].to_vec()),
-            OwnedColumn::BigInt(column_a[3..].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[3..].to_vec()),
+            OwnedColumn::BigInt(meta, column_a[3..].to_vec()),
         ];
         let new_commitments =
             Vec::<DoryCommitment>::from_columns_with_offset(&new_columns, 3, &setup);
@@ -398,6 +404,7 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -408,15 +415,15 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments_a = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
 
         let full_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
         ];
 
         let commitments_b =
@@ -441,6 +448,7 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
+        let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
         let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
         let prover_setup = ProverSetup::from(&public_parameters);
         let setup = DoryProverPublicSetup::new(&prover_setup, 2);
@@ -449,8 +457,8 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a[..3].to_vec()),
-            OwnedColumn::VarChar(column_b[..3].to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a[..3].to_vec()),
+            OwnedColumn::VarChar(meta, column_b[..3].to_vec()),
         ];
 
         let commitments = Vec::<DoryCommitment>::from_columns_with_offset(&columns, 0, &setup);
@@ -463,7 +471,7 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let full_columns = vec![OwnedColumn::<DoryScalar>::BigInt(column_a.to_vec())];
+        let full_columns = vec![OwnedColumn::<DoryScalar>::BigInt(meta, column_a.to_vec())];
         let full_commitments =
             Vec::<DoryCommitment>::from_columns_with_offset(&full_columns, 0, &setup);
         assert!(matches!(
@@ -472,9 +480,9 @@ mod tests {
         ));
 
         let full_columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(column_a.to_vec()),
-            OwnedColumn::VarChar(column_b.to_vec()),
-            OwnedColumn::BigInt(column_a.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(meta, column_a.to_vec()),
+            OwnedColumn::VarChar(meta, column_b.to_vec()),
+            OwnedColumn::BigInt(meta, column_a.to_vec()),
         ];
         let full_commitments =
             Vec::<DoryCommitment>::from_columns_with_offset(&full_columns, 0, &setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -100,11 +100,10 @@ impl Commitment for DoryCommitment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
             commitment::{NumColumnsMismatch, VecCommitmentExt},
-            database::{Column, OwnedColumn},
+            database::{Column, ColumnTypeAssociatedData, OwnedColumn},
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -100,6 +100,7 @@ impl Commitment for DoryCommitment {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::base::database::ColumnTypeAssociatedData;
     use crate::{
         base::{
             commitment::{NumColumnsMismatch, VecCommitmentExt},
@@ -108,7 +109,6 @@ mod tests {
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
     use ark_ec::pairing::Pairing;
-    use crate::base::database::ColumnTypeAssociatedData;
 
     #[test]
     fn we_can_convert_from_columns() {
@@ -132,7 +132,10 @@ mod tests {
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
 
         let columns = vec![
-            OwnedColumn::<DoryScalar>::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, column_a.to_vec()),
+            OwnedColumn::<DoryScalar>::BigInt(
+                ColumnTypeAssociatedData::NOT_NULLABLE,
+                column_a.to_vec(),
+            ),
             OwnedColumn::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE, column_b.to_vec()),
         ];
 
@@ -229,7 +232,10 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec())];
+        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(
+            meta,
+            column_a[3..].to_vec(),
+        )];
         assert!(matches!(
             commitments.try_append_rows_with_offset(&new_columns, 3, &setup),
             Err(NumColumnsMismatch)
@@ -381,7 +387,10 @@ mod tests {
             Err(NumColumnsMismatch)
         ));
 
-        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(meta, column_a[3..].to_vec())];
+        let new_columns = vec![OwnedColumn::<DoryScalar>::BigInt(
+            meta,
+            column_a[3..].to_vec(),
+        )];
         let new_commitments =
             Vec::<DoryCommitment>::from_columns_with_offset(&new_columns, 3, &setup);
         assert!(matches!(

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -57,15 +57,15 @@ fn output_bit_table(
 /// * `column_type` - The type of a committable column.
 const fn min_as_f(column_type: ColumnType) -> F {
     match column_type {
-        ColumnType::TinyInt => MontFp!("-128"),
-        ColumnType::SmallInt => MontFp!("-32768"),
-        ColumnType::Int => MontFp!("-2147483648"),
-        ColumnType::BigInt | ColumnType::TimestampTZ(_, _) => MontFp!("-9223372036854775808"),
-        ColumnType::Int128 => MontFp!("-170141183460469231731687303715884105728"),
-        ColumnType::Decimal75(_, _)
-        | ColumnType::Scalar
-        | ColumnType::VarChar
-        | ColumnType::Boolean => MontFp!("0"),
+        ColumnType::TinyInt(_) => MontFp!("-128"),
+        ColumnType::SmallInt(_) => MontFp!("-32768"),
+        ColumnType::Int(_) => MontFp!("-2147483648"),
+        ColumnType::BigInt(_) | ColumnType::TimestampTZ(_, _, _) => MontFp!("-9223372036854775808"),
+        ColumnType::Int128(_) => MontFp!("-170141183460469231731687303715884105728"),
+        ColumnType::Decimal75(_, _, _)
+        | ColumnType::Scalar(_)
+        | ColumnType::VarChar(_)
+        | ColumnType::Boolean(_) => MontFp!("0"),
     }
 }
 

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,6 +1,5 @@
-use crate::base::database::ColumnTypeKind;
 use crate::base::{
-    database::{ColumnOperationError, ColumnType},
+    database::{ColumnOperationError, ColumnType, ColumnTypeKind},
     math::decimal::DecimalError,
 };
 use alloc::{

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeKind;
 use crate::base::{
     database::{ColumnOperationError, ColumnType},
     math::decimal::DecimalError,
@@ -31,6 +32,15 @@ pub enum ConversionError {
     MissingColumnWithoutTable {
         /// The missing column identifier
         identifier: Box<Identifier>,
+    },
+
+    #[snafu(display("Expected '{expected}' but found '{actual}'"))]
+    /// Invalid data type received
+    InvalidDataTypeKind {
+        /// Expected data type
+        expected: ColumnTypeKind,
+        /// Actual data type found
+        actual: ColumnTypeKind,
     },
 
     #[snafu(display("Expected '{expected}' but found '{actual}'"))]

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -131,7 +131,7 @@ impl<'a> QueryContextBuilder<'a> {
     /// Visits the expression and returns its data type.
     fn visit_expr(&mut self, expr: &Expression) -> ConversionResult<ColumnType> {
         match expr {
-            Expression::Wildcard => Ok(ColumnType::BigInt(ColumnTypeAssociatedData::default())), // Since COUNT(*) = COUNT(1)
+            Expression::Wildcard => Ok(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)), // Since COUNT(*) = COUNT(1)
             Expression::Literal(literal) => self.visit_literal(literal),
             Expression::Column(_) => self.visit_column_expr(expr),
             Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
@@ -165,7 +165,7 @@ impl<'a> QueryContextBuilder<'a> {
             | BinaryOperator::Or
             | BinaryOperator::Equal
             | BinaryOperator::GreaterThanOrEqual
-            | BinaryOperator::LessThanOrEqual => Ok(ColumnType::Boolean(ColumnTypeAssociatedData::default())),
+            | BinaryOperator::LessThanOrEqual => Ok(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)),
             BinaryOperator::Multiply
             | BinaryOperator::Division
             | BinaryOperator::Subtract
@@ -185,7 +185,7 @@ impl<'a> QueryContextBuilder<'a> {
                     Ok(dtype)
                 } else {
                     Err(ConversionError::InvalidDataType {
-                        expected: ColumnType::Boolean(ColumnTypeAssociatedData::default()),
+                        expected: ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
                         actual: dtype,
                     })
                 }
@@ -204,7 +204,7 @@ impl<'a> QueryContextBuilder<'a> {
          match (op, expr_dtype) {
             (AggregationOperator::Count, _) => {
                 self.context.set_in_agg_scope(false)?;
-                Ok(ColumnType::BigInt(ColumnTypeAssociatedData::default()))
+                Ok(ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
             },
             (_, ColumnType::VarChar(_)) => Err(ConversionError::non_numeric_expr_in_agg(
                 expr_dtype.to_string(),
@@ -219,7 +219,7 @@ impl<'a> QueryContextBuilder<'a> {
 
     #[allow(clippy::unused_self)]
     fn visit_literal(&self, literal: &Literal) -> Result<ColumnType, ConversionError> {
-        let meta =  ColumnTypeAssociatedData::default();
+        let meta =  ColumnTypeAssociatedData::NOT_NULLABLE;
         match literal {
             Literal::Boolean(_) => Ok(ColumnType::Boolean(meta)),
             Literal::BigInt(_) => Ok(ColumnType::BigInt(meta)),

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -181,7 +181,7 @@ impl<'a> QueryContextBuilder<'a> {
         match op {
             UnaryOperator::Not => {
                 let dtype = self.visit_expr(expr)?;
-                if let ColumnType::Boolean(_) = expr {
+                if let ColumnType::Boolean(_) = dtype {
                     Ok(dtype)
                 } else {
                     Err(ConversionError::InvalidDataType {

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -1,9 +1,8 @@
 use super::{ConversionError, ConversionResult, QueryContext};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{
         try_add_subtract_column_types, try_multiply_column_types, ColumnRef, ColumnType,
-        SchemaAccessor, TableRef,
+        ColumnTypeAssociatedData, SchemaAccessor, TableRef,
     },
     math::decimal::Precision,
 };

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1685,15 +1685,15 @@ fn arithmetic_operations_are_not_allowed_with_varchar_column() {
 fn varchar_column_is_not_allowed_within_numeric_aggregations() {
     assert_eq!(
         query!(select: ["sum(s)"], should_err: true),
-        ConversionError::non_numeric_expr_in_agg("varchar", "sum")
+        ConversionError::non_numeric_expr_in_agg("varchar not null", "sum")
     );
     assert_eq!(
         query!(select: ["max(s)"], should_err: true),
-        ConversionError::non_numeric_expr_in_agg("varchar", "max")
+        ConversionError::non_numeric_expr_in_agg("varchar not null", "max")
     );
     assert_eq!(
         query!(select: ["min(s)"], should_err: true),
-        ConversionError::non_numeric_expr_in_agg("varchar", "min")
+        ConversionError::non_numeric_expr_in_agg("varchar not null", "min")
     );
 }
 

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -116,7 +116,7 @@ fn we_can_convert_an_ast_with_one_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -137,7 +137,7 @@ fn we_can_convert_an_ast_with_one_column_and_i128_data() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::Int128(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::Int128(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -158,7 +158,7 @@ fn we_can_convert_an_ast_with_one_column_and_a_filter_by_a_string_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 'abc'", &accessor);
@@ -179,8 +179,8 @@ fn we_cannot_convert_an_ast_with_duplicate_aliases() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -203,7 +203,7 @@ fn we_dont_have_duplicate_filter_result_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -228,9 +228,9 @@ fn we_can_convert_an_ast_with_two_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a,  b from sxt_tab where c = 123", &accessor);
@@ -251,9 +251,9 @@ fn we_can_convert_an_ast_with_two_columns_and_arithmetic() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -284,8 +284,8 @@ fn we_can_parse_all_result_columns_with_select_star() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -306,8 +306,8 @@ fn we_can_convert_an_ast_with_one_positive_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b = +4", &accessor);
@@ -328,8 +328,8 @@ fn we_can_convert_an_ast_with_one_not_equals_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <> +4", &accessor);
@@ -350,8 +350,8 @@ fn we_can_convert_an_ast_with_one_negative_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <= -4", &accessor);
@@ -372,9 +372,9 @@ fn we_can_convert_an_ast_with_cond_and() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -402,9 +402,9 @@ fn we_can_convert_an_ast_with_cond_or() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -435,9 +435,9 @@ fn we_can_convert_an_ast_with_conds_or_not() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -509,7 +509,7 @@ fn we_can_convert_an_ast_with_the_min_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -537,7 +537,7 @@ fn we_can_convert_an_ast_with_the_max_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -565,8 +565,8 @@ fn we_can_convert_an_ast_using_an_aliased_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -597,7 +597,7 @@ fn we_cannot_convert_an_ast_with_a_nonexistent_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -609,7 +609,7 @@ fn we_cannot_convert_an_ast_with_a_column_type_different_than_equal_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where b = 123", &accessor);
@@ -621,7 +621,7 @@ fn we_can_convert_an_ast_with_a_schema() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from eth.sxt_tab where a = 3", &accessor);
@@ -642,7 +642,7 @@ fn we_can_convert_an_ast_without_any_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let expected_ast = QueryExpr::new(
@@ -675,8 +675,8 @@ fn we_can_parse_order_by_with_a_single_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3 order by b", &accessor);
@@ -697,8 +697,8 @@ fn we_can_parse_order_by_with_multiple_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -727,8 +727,8 @@ fn we_can_parse_order_by_referencing_an_alias_associated_with_column_b_but_with_
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -756,7 +756,7 @@ fn we_cannot_parse_order_by_referencing_a_column_name_instead_of_an_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -772,8 +772,8 @@ fn we_cannot_parse_order_by_referencing_invalid_aliased_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     // Note: While this operation is acceptable with PostgreSQL, we do not currently support it.
@@ -789,8 +789,8 @@ fn we_cannot_parse_order_by_referencing_an_alias_name_associated_with_two_differ
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -828,8 +828,8 @@ fn we_can_parse_order_by_queries_with_the_same_column_name_appearing_more_than_o
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     for order_by in ["s", "d"] {
@@ -864,7 +864,7 @@ fn we_can_parse_a_query_having_a_simple_limit_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 3", &accessor);
@@ -885,7 +885,7 @@ fn slice_is_still_applied_when_limit_is_u64_max_and_offset_is_zero() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 0", &accessor);
@@ -906,7 +906,7 @@ fn we_can_parse_a_query_having_a_simple_positive_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 7", &accessor);
@@ -927,7 +927,7 @@ fn we_can_parse_a_query_having_a_negative_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset -7", &accessor);
@@ -948,7 +948,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 55 offset 3", &accessor);
@@ -973,8 +973,8 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "boolean".parse().unwrap() =>ColumnType::Boolean(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "boolean".parse().unwrap() =>ColumnType::Boolean(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1011,8 +1011,8 @@ fn we_can_do_provable_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1039,8 +1039,8 @@ fn we_can_do_provable_group_by_without_sum() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1067,9 +1067,9 @@ fn we_can_do_provable_group_by_with_two_group_by_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "state".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "state".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1096,9 +1096,9 @@ fn we_can_do_provable_group_by_with_two_sums_and_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "tax".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "tax".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1131,8 +1131,8 @@ fn we_can_group_by_without_using_aggregate_functions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1202,8 +1202,8 @@ fn we_cannot_parse_non_aggregated_or_non_group_by_columns_in_the_select_clause()
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -1219,8 +1219,8 @@ fn alias_references_are_not_allowed_in_the_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -1241,8 +1241,8 @@ fn order_by_cannot_reference_an_invalid_group_by_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -1263,8 +1263,8 @@ fn group_by_column_cannot_be_a_column_result_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -1293,9 +1293,9 @@ fn we_can_parse_a_query_having_group_by_with_the_same_name_as_the_aggregation_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1323,9 +1323,9 @@ fn count_aggregate_functions_can_be_used_with_non_numeric_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1357,9 +1357,9 @@ fn count_all_uses_the_first_group_by_identifier_as_default_result_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1387,9 +1387,9 @@ fn aggregate_result_columns_cannot_reference_invalid_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     invalid_query_to_provable_ast(
@@ -1405,9 +1405,9 @@ fn we_can_use_the_same_result_columns_with_different_aliases_and_associate_it_wi
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1465,10 +1465,10 @@ fn we_can_parse_a_simple_add_mul_sub_div_arithmetic_expressions_in_the_result_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "f".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "h".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "f".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNullable),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "h".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNullable),
         },
     );
     // TODO: add `a / b as a_div_b` result expr once polars properly
@@ -1510,10 +1510,10 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "h".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "h".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1565,10 +1565,10 @@ fn we_can_parse_arithmetic_expression_within_aggregations_in_the_result_expr() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "k".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "k".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     );
     let ast = query_to_provable_ast(
@@ -1933,9 +1933,9 @@ fn query_expr_for_test_table(sql_text: &str) -> QueryExpr<RistrettoPoint> {
     let schema_accessor = schema_accessor_from_table_ref_with_schema(
         "test.table".parse().unwrap(),
         indexmap! {
-            "bigint_column".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
-            "varchar_column".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
-            "int128_column".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
+            "bigint_column".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
+            "varchar_column".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
+            "int128_column".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNullable),
         },
     );
     let default_schema = "test".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1,8 +1,7 @@
 use super::ConversionError;
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
-        database::{ColumnType, TableRef, TestSchemaAccessor},
+        database::{ColumnType, ColumnTypeAssociatedData, TableRef, TestSchemaAccessor},
         map::{indexmap, IndexMap, IndexSet},
     },
     sql::{

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -22,6 +22,7 @@ use proof_of_sql_parser::{
     },
     Identifier,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// # Panics
 ///
@@ -54,19 +55,20 @@ pub fn schema_accessor_from_table_ref_with_schema(
 }
 
 fn get_test_accessor() -> (TableRef, TestSchemaAccessor) {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let table = "sxt.t".parse().unwrap();
     let accessor = schema_accessor_from_table_ref_with_schema(
         table,
         indexmap! {
-            "s".parse().unwrap() => ColumnType::VarChar,
-            "i".parse().unwrap() => ColumnType::BigInt,
-            "d".parse().unwrap() => ColumnType::Int128,
-            "s0".parse().unwrap() => ColumnType::VarChar,
-            "i0".parse().unwrap() => ColumnType::BigInt,
-            "d0".parse().unwrap() => ColumnType::Int128,
-            "s1".parse().unwrap() => ColumnType::VarChar,
-            "i1".parse().unwrap() => ColumnType::BigInt,
-            "d1".parse().unwrap() => ColumnType::Int128,
+            "s".parse().unwrap() => ColumnType::VarChar(meta),
+            "i".parse().unwrap() => ColumnType::BigInt(meta),
+            "d".parse().unwrap() => ColumnType::Int128(meta),
+            "s0".parse().unwrap() => ColumnType::VarChar(meta),
+            "i0".parse().unwrap() => ColumnType::BigInt(meta),
+            "d0".parse().unwrap() => ColumnType::Int128(meta),
+            "s1".parse().unwrap() => ColumnType::VarChar(meta),
+            "i1".parse().unwrap() => ColumnType::BigInt(meta),
+            "d1".parse().unwrap() => ColumnType::Int128(meta),
         },
     );
     (table, accessor)
@@ -115,7 +117,7 @@ fn we_can_convert_an_ast_with_one_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -136,7 +138,7 @@ fn we_can_convert_an_ast_with_one_column_and_i128_data() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::Int128,
+            "a".parse().unwrap() => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -157,7 +159,7 @@ fn we_can_convert_an_ast_with_one_column_and_a_filter_by_a_string_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::VarChar,
+            "a".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 'abc'", &accessor);
@@ -178,8 +180,8 @@ fn we_cannot_convert_an_ast_with_duplicate_aliases() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -202,7 +204,7 @@ fn we_dont_have_duplicate_filter_result_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -227,9 +229,9 @@ fn we_can_convert_an_ast_with_two_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a,  b from sxt_tab where c = 123", &accessor);
@@ -250,9 +252,9 @@ fn we_can_convert_an_ast_with_two_columns_and_arithmetic() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -283,8 +285,8 @@ fn we_can_parse_all_result_columns_with_select_star() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -305,8 +307,8 @@ fn we_can_convert_an_ast_with_one_positive_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b = +4", &accessor);
@@ -327,8 +329,8 @@ fn we_can_convert_an_ast_with_one_not_equals_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <> +4", &accessor);
@@ -349,8 +351,8 @@ fn we_can_convert_an_ast_with_one_negative_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <= -4", &accessor);
@@ -371,9 +373,9 @@ fn we_can_convert_an_ast_with_cond_and() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -401,9 +403,9 @@ fn we_can_convert_an_ast_with_cond_or() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -434,9 +436,9 @@ fn we_can_convert_an_ast_with_conds_or_not() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -460,14 +462,15 @@ fn we_can_convert_an_ast_with_conds_or_not() {
 
 #[test]
 fn we_can_convert_an_ast_with_conds_not_and_or() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "c".parse().unwrap() => ColumnType::BigInt,
-            "f".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(meta),
+            "b".parse().unwrap() => ColumnType::BigInt(meta),
+            "c".parse().unwrap() => ColumnType::BigInt(meta),
+            "f".parse().unwrap() => ColumnType::BigInt(meta),
         },
     );
     let ast = query_to_provable_ast(
@@ -507,7 +510,7 @@ fn we_can_convert_an_ast_with_the_min_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -535,7 +538,7 @@ fn we_can_convert_an_ast_with_the_max_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -563,8 +566,8 @@ fn we_can_convert_an_ast_using_an_aliased_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -595,7 +598,7 @@ fn we_cannot_convert_an_ast_with_a_nonexistent_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -607,7 +610,7 @@ fn we_cannot_convert_an_ast_with_a_column_type_different_than_equal_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar,
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where b = 123", &accessor);
@@ -619,7 +622,7 @@ fn we_can_convert_an_ast_with_a_schema() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from eth.sxt_tab where a = 3", &accessor);
@@ -640,7 +643,7 @@ fn we_can_convert_an_ast_without_any_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let expected_ast = QueryExpr::new(
@@ -673,8 +676,8 @@ fn we_can_parse_order_by_with_a_single_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3 order by b", &accessor);
@@ -695,8 +698,8 @@ fn we_can_parse_order_by_with_multiple_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -725,8 +728,8 @@ fn we_can_parse_order_by_referencing_an_alias_associated_with_column_b_but_with_
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "name".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -754,7 +757,7 @@ fn we_cannot_parse_order_by_referencing_a_column_name_instead_of_an_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -770,8 +773,8 @@ fn we_cannot_parse_order_by_referencing_invalid_aliased_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     // Note: While this operation is acceptable with PostgreSQL, we do not currently support it.
@@ -787,8 +790,8 @@ fn we_cannot_parse_order_by_referencing_an_alias_name_associated_with_two_differ
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "name".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -826,8 +829,8 @@ fn we_can_parse_order_by_queries_with_the_same_column_name_appearing_more_than_o
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "name".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     for order_by in ["s", "d"] {
@@ -862,7 +865,7 @@ fn we_can_parse_a_query_having_a_simple_limit_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 3", &accessor);
@@ -883,7 +886,7 @@ fn slice_is_still_applied_when_limit_is_u64_max_and_offset_is_zero() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 0", &accessor);
@@ -904,7 +907,7 @@ fn we_can_parse_a_query_having_a_simple_positive_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 7", &accessor);
@@ -925,7 +928,7 @@ fn we_can_parse_a_query_having_a_negative_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset -7", &accessor);
@@ -946,7 +949,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 55 offset 3", &accessor);
@@ -971,8 +974,8 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "boolean".parse().unwrap() => ColumnType::Boolean,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "boolean".parse().unwrap() =>ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1009,8 +1012,8 @@ fn we_can_do_provable_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1037,8 +1040,8 @@ fn we_can_do_provable_group_by_without_sum() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1065,9 +1068,9 @@ fn we_can_do_provable_group_by_with_two_group_by_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "state".parse().unwrap() => ColumnType::VarChar,
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "state".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1094,9 +1097,9 @@ fn we_can_do_provable_group_by_with_two_sums_and_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "tax".parse().unwrap() => ColumnType::BigInt,
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "tax".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1129,8 +1132,8 @@ fn we_can_group_by_without_using_aggregate_functions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1200,8 +1203,8 @@ fn we_cannot_parse_non_aggregated_or_non_group_by_columns_in_the_select_clause()
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -1217,8 +1220,8 @@ fn alias_references_are_not_allowed_in_the_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -1239,8 +1242,8 @@ fn order_by_cannot_reference_an_invalid_group_by_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -1261,8 +1264,8 @@ fn group_by_column_cannot_be_a_column_result_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -1291,9 +1294,9 @@ fn we_can_parse_a_query_having_group_by_with_the_same_name_as_the_aggregation_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
-            "bonus".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1321,9 +1324,9 @@ fn count_aggregate_functions_can_be_used_with_non_numeric_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
-            "bonus".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1355,9 +1358,9 @@ fn count_all_uses_the_first_group_by_identifier_as_default_result_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
-            "bonus".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1385,9 +1388,9 @@ fn aggregate_result_columns_cannot_reference_invalid_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
-            "bonus".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     invalid_query_to_provable_ast(
@@ -1403,9 +1406,9 @@ fn we_can_use_the_same_result_columns_with_different_aliases_and_associate_it_wi
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt,
-            "department".parse().unwrap() => ColumnType::BigInt,
-            "bonus".parse().unwrap() => ColumnType::VarChar,
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1463,10 +1466,10 @@ fn we_can_parse_a_simple_add_mul_sub_div_arithmetic_expressions_in_the_result_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt,
-            "f".parse().unwrap() => ColumnType::Int128,
-            "b".parse().unwrap() => ColumnType::BigInt,
-            "h".parse().unwrap() => ColumnType::Int128,
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "f".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "h".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     // TODO: add `a / b as a_div_b` result expr once polars properly
@@ -1508,10 +1511,10 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt,
-            "f".parse().unwrap() => ColumnType::BigInt,
-            "g".parse().unwrap() => ColumnType::BigInt,
-            "h".parse().unwrap() => ColumnType::BigInt,
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "h".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1563,10 +1566,10 @@ fn we_can_parse_arithmetic_expression_within_aggregations_in_the_result_expr() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt,
-            "f".parse().unwrap() => ColumnType::BigInt,
-            "g".parse().unwrap() => ColumnType::BigInt,
-            "k".parse().unwrap() => ColumnType::BigInt,
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "k".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let ast = query_to_provable_ast(
@@ -1636,43 +1639,45 @@ fn we_cannot_use_non_grouped_columns_outside_agg() {
 
 #[test]
 fn varchar_column_is_not_compatible_with_integer_column() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     assert_eq!(
         query!(select: ["-123 * s"], should_err: true),
         ConversionError::DataTypeMismatch {
-            left_type: ColumnType::BigInt.to_string(),
-            right_type: ColumnType::VarChar.to_string()
+            left_type: ColumnType::BigInt(meta).to_string(),
+            right_type: ColumnType::VarChar(meta).to_string()
         }
     );
     assert_eq!(
         query!(select: ["i - s"], should_err: true),
         ConversionError::DataTypeMismatch {
-            left_type: ColumnType::BigInt.to_string(),
-            right_type: ColumnType::VarChar.to_string()
+            left_type: ColumnType::BigInt(meta).to_string(),
+            right_type: ColumnType::VarChar(meta).to_string()
         }
     );
     assert_eq!(
         query!(select: ["s"], filter: "'abc' = i", should_err: true),
         ConversionError::DataTypeMismatch {
-            left_type: ColumnType::VarChar.to_string(),
-            right_type: ColumnType::BigInt.to_string(),
+            left_type: ColumnType::VarChar(meta).to_string(),
+            right_type: ColumnType::BigInt(meta).to_string(),
         }
     );
     assert_eq!(
         query!(select: ["s"], filter: "'abc' != i", should_err: true),
         ConversionError::DataTypeMismatch {
-            left_type: ColumnType::VarChar.to_string(),
-            right_type: ColumnType::BigInt.to_string(),
+            left_type: ColumnType::VarChar(meta).to_string(),
+            right_type: ColumnType::BigInt(meta).to_string(),
         }
     );
 }
 
 #[test]
 fn arithmetic_operations_are_not_allowed_with_varchar_column() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     assert_eq!(
         query!(select: ["s - s1"], should_err: true),
         ConversionError::DataTypeMismatch {
-            left_type: ColumnType::VarChar.to_string(),
-            right_type: ColumnType::VarChar.to_string()
+            left_type: ColumnType::VarChar(meta).to_string(),
+            right_type: ColumnType::VarChar(meta).to_string()
         }
     );
 }
@@ -1929,9 +1934,9 @@ fn query_expr_for_test_table(sql_text: &str) -> QueryExpr<RistrettoPoint> {
     let schema_accessor = schema_accessor_from_table_ref_with_schema(
         "test.table".parse().unwrap(),
         indexmap! {
-            "bigint_column".parse().unwrap() => ColumnType::BigInt,
-            "varchar_column".parse().unwrap() => ColumnType::VarChar,
-            "int128_column".parse().unwrap() => ColumnType::Int128,
+            "bigint_column".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "varchar_column".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "int128_column".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     );
     let default_schema = "test".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1,7 +1,7 @@
 use super::ConversionError;
 use crate::{
     base::{
-        database::{ColumnType, ColumnTypeAssociatedData, TableRef, TestSchemaAccessor},
+        database::{ColumnNullability, ColumnType, TableRef, TestSchemaAccessor},
         map::{indexmap, IndexMap, IndexSet},
     },
     sql::{
@@ -54,7 +54,7 @@ pub fn schema_accessor_from_table_ref_with_schema(
 }
 
 fn get_test_accessor() -> (TableRef, TestSchemaAccessor) {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table = "sxt.t".parse().unwrap();
     let accessor = schema_accessor_from_table_ref_with_schema(
         table,
@@ -116,7 +116,7 @@ fn we_can_convert_an_ast_with_one_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -137,7 +137,7 @@ fn we_can_convert_an_ast_with_one_column_and_i128_data() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::Int128(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 3", &accessor);
@@ -158,7 +158,7 @@ fn we_can_convert_an_ast_with_one_column_and_a_filter_by_a_string_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where a = 'abc'", &accessor);
@@ -179,8 +179,8 @@ fn we_cannot_convert_an_ast_with_duplicate_aliases() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -203,7 +203,7 @@ fn we_dont_have_duplicate_filter_result_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -228,9 +228,9 @@ fn we_can_convert_an_ast_with_two_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a,  b from sxt_tab where c = 123", &accessor);
@@ -251,9 +251,9 @@ fn we_can_convert_an_ast_with_two_columns_and_arithmetic() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -284,8 +284,8 @@ fn we_can_parse_all_result_columns_with_select_star() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -306,8 +306,8 @@ fn we_can_convert_an_ast_with_one_positive_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b = +4", &accessor);
@@ -328,8 +328,8 @@ fn we_can_convert_an_ast_with_one_not_equals_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <> +4", &accessor);
@@ -350,8 +350,8 @@ fn we_can_convert_an_ast_with_one_negative_cond() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab where b <= -4", &accessor);
@@ -372,9 +372,9 @@ fn we_can_convert_an_ast_with_cond_and() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -402,9 +402,9 @@ fn we_can_convert_an_ast_with_cond_or() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -435,9 +435,9 @@ fn we_can_convert_an_ast_with_conds_or_not() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -461,7 +461,7 @@ fn we_can_convert_an_ast_with_conds_or_not() {
 
 #[test]
 fn we_can_convert_an_ast_with_conds_not_and_or() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
@@ -509,7 +509,7 @@ fn we_can_convert_an_ast_with_the_min_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -537,7 +537,7 @@ fn we_can_convert_an_ast_with_the_max_i128_filter_value_and_const() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -565,8 +565,8 @@ fn we_can_convert_an_ast_using_an_aliased_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -597,7 +597,7 @@ fn we_cannot_convert_an_ast_with_a_nonexistent_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where a = 3", &accessor);
@@ -609,7 +609,7 @@ fn we_cannot_convert_an_ast_with_a_column_type_different_than_equal_literal() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(t, "select * from sxt_tab where b = 123", &accessor);
@@ -621,7 +621,7 @@ fn we_can_convert_an_ast_with_a_schema() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from eth.sxt_tab where a = 3", &accessor);
@@ -642,7 +642,7 @@ fn we_can_convert_an_ast_without_any_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let expected_ast = QueryExpr::new(
@@ -675,8 +675,8 @@ fn we_can_parse_order_by_with_a_single_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select * from sxt_tab where a = 3 order by b", &accessor);
@@ -697,8 +697,8 @@ fn we_can_parse_order_by_with_multiple_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -727,8 +727,8 @@ fn we_can_parse_order_by_referencing_an_alias_associated_with_column_b_but_with_
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -756,7 +756,7 @@ fn we_cannot_parse_order_by_referencing_a_column_name_instead_of_an_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -772,8 +772,8 @@ fn we_cannot_parse_order_by_referencing_invalid_aliased_expressions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     // Note: While this operation is acceptable with PostgreSQL, we do not currently support it.
@@ -789,8 +789,8 @@ fn we_cannot_parse_order_by_referencing_an_alias_name_associated_with_two_differ
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -828,8 +828,8 @@ fn we_can_parse_order_by_queries_with_the_same_column_name_appearing_more_than_o
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "name".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "name".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     for order_by in ["s", "d"] {
@@ -864,7 +864,7 @@ fn we_can_parse_a_query_having_a_simple_limit_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 3", &accessor);
@@ -885,7 +885,7 @@ fn slice_is_still_applied_when_limit_is_u64_max_and_offset_is_zero() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 0", &accessor);
@@ -906,7 +906,7 @@ fn we_can_parse_a_query_having_a_simple_positive_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset 7", &accessor);
@@ -927,7 +927,7 @@ fn we_can_parse_a_query_having_a_negative_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab offset -7", &accessor);
@@ -948,7 +948,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(t, "select a from sxt_tab limit 55 offset 3", &accessor);
@@ -973,8 +973,8 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "boolean".parse().unwrap() =>ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "boolean".parse().unwrap() =>ColumnType::Boolean(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1011,8 +1011,8 @@ fn we_can_do_provable_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1039,8 +1039,8 @@ fn we_can_do_provable_group_by_without_sum() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1067,9 +1067,9 @@ fn we_can_do_provable_group_by_with_two_group_by_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "state".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "state".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1096,9 +1096,9 @@ fn we_can_do_provable_group_by_with_two_sums_and_filter() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "tax".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "tax".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1131,8 +1131,8 @@ fn we_can_group_by_without_using_aggregate_functions() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1202,8 +1202,8 @@ fn we_cannot_parse_non_aggregated_or_non_group_by_columns_in_the_select_clause()
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -1219,8 +1219,8 @@ fn alias_references_are_not_allowed_in_the_group_by() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -1241,8 +1241,8 @@ fn order_by_cannot_reference_an_invalid_group_by_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -1263,8 +1263,8 @@ fn group_by_column_cannot_be_a_column_result_alias() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -1293,9 +1293,9 @@ fn we_can_parse_a_query_having_group_by_with_the_same_name_as_the_aggregation_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1323,9 +1323,9 @@ fn count_aggregate_functions_can_be_used_with_non_numeric_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1357,9 +1357,9 @@ fn count_all_uses_the_first_group_by_identifier_as_default_result_column() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1387,9 +1387,9 @@ fn aggregate_result_columns_cannot_reference_invalid_columns() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     invalid_query_to_provable_ast(
@@ -1405,9 +1405,9 @@ fn we_can_use_the_same_result_columns_with_different_aliases_and_associate_it_wi
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "salary".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "department".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "salary".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "department".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "bonus".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1465,10 +1465,10 @@ fn we_can_parse_a_simple_add_mul_sub_div_arithmetic_expressions_in_the_result_ex
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "a".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "f".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "h".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "a".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "f".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "h".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
         },
     );
     // TODO: add `a / b as a_div_b` result expr once polars properly
@@ -1510,10 +1510,10 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "f".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "g".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "h".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "h".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1565,10 +1565,10 @@ fn we_can_parse_arithmetic_expression_within_aggregations_in_the_result_expr() {
     let accessor = schema_accessor_from_table_ref_with_schema(
         t,
         indexmap! {
-            "c".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "f".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "g".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "k".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "c".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "f".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "g".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "k".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
         },
     );
     let ast = query_to_provable_ast(
@@ -1638,7 +1638,7 @@ fn we_cannot_use_non_grouped_columns_outside_agg() {
 
 #[test]
 fn varchar_column_is_not_compatible_with_integer_column() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     assert_eq!(
         query!(select: ["-123 * s"], should_err: true),
         ConversionError::DataTypeMismatch {
@@ -1671,7 +1671,7 @@ fn varchar_column_is_not_compatible_with_integer_column() {
 
 #[test]
 fn arithmetic_operations_are_not_allowed_with_varchar_column() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     assert_eq!(
         query!(select: ["s - s1"], should_err: true),
         ConversionError::DataTypeMismatch {
@@ -1933,9 +1933,9 @@ fn query_expr_for_test_table(sql_text: &str) -> QueryExpr<RistrettoPoint> {
     let schema_accessor = schema_accessor_from_table_ref_with_schema(
         "test.table".parse().unwrap(),
         indexmap! {
-            "bigint_column".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "varchar_column".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
-            "int128_column".parse().unwrap() =>ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "bigint_column".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNull),
+            "varchar_column".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNull),
+            "int128_column".parse().unwrap() =>ColumnType::Int128(ColumnNullability::NotNull),
         },
     );
     let default_schema = "test".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1,4 +1,5 @@
 use super::ConversionError;
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{ColumnType, TableRef, TestSchemaAccessor},
@@ -22,7 +23,6 @@ use proof_of_sql_parser::{
     },
     Identifier,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// # Panics
 ///

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -33,7 +33,7 @@ impl<'a> WhereExprBuilder<'a> {
                 let expr_plan = self.builder.build(&where_expr)?;
                 // Ensure that the expression is a boolean expression
                 match expr_plan.data_type() {
-                    ColumnType::Boolean => Ok(expr_plan),
+                    ColumnType::Boolean(_) => Ok(expr_plan),
                     _ => Err(ConversionError::NonbooleanWhereClause {
                         datatype: expr_plan.data_type(),
                     }),

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -17,6 +17,7 @@ use proof_of_sql_parser::{
     utility::*,
     Identifier, SelectStatement,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// # Panics
 ///
@@ -28,40 +29,41 @@ use proof_of_sql_parser::{
 ///   call is expected to succeed; however, if it encounters an invalid precision value, it will
 ///   cause a panic when `unwrap()` is called.
 fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let tab_ref = "sxt.sxt_tab".parse().unwrap();
     let mut column_mapping = IndexMap::default();
     // Setup column mapping
     column_mapping.insert(
         ident("boolean_column"),
-        ColumnRef::new(tab_ref, ident("boolean_column"), ColumnType::Boolean),
+        ColumnRef::new(tab_ref, ident("boolean_column"), ColumnType::Boolean(meta)),
     );
     column_mapping.insert(
         ident("decimal_column"),
         ColumnRef::new(
             tab_ref,
             ident("decimal_column"),
-            ColumnType::Decimal75(Precision::new(7).unwrap(), 2),
+            ColumnType::Decimal75(meta, Precision::new(7).unwrap(), 2),
         ),
     );
     column_mapping.insert(
         ident("int128_column"),
-        ColumnRef::new(tab_ref, ident("int128_column"), ColumnType::Int128),
+        ColumnRef::new(tab_ref, ident("int128_column"), ColumnType::Int128(meta)),
     );
     column_mapping.insert(
         ident("bigint_column"),
-        ColumnRef::new(tab_ref, ident("bigint_column"), ColumnType::BigInt),
+        ColumnRef::new(tab_ref, ident("bigint_column"), ColumnType::BigInt(meta)),
     );
 
     column_mapping.insert(
         ident("varchar_column"),
-        ColumnRef::new(tab_ref, ident("varchar_column"), ColumnType::VarChar),
+        ColumnRef::new(tab_ref, ident("varchar_column"), ColumnType::VarChar(meta)),
     );
     column_mapping.insert(
         ident("timestamp_second_column"),
         ColumnRef::new(
             tab_ref,
             ident("timestamp_second_column"),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+            ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
         ),
     );
     column_mapping.insert(
@@ -69,7 +71,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             ident("timestamp_millisecond_column"),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
+            ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
         ),
     );
     column_mapping.insert(
@@ -77,7 +79,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             ident("timestamp_microsecond_column"),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
+            ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
         ),
     );
     column_mapping.insert(
@@ -85,7 +87,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             ident("timestamp_nanosecond_column"),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
+            ColumnType::TimestampTZ(meta, PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
         ),
     );
     column_mapping
@@ -151,7 +153,7 @@ fn we_can_directly_check_whether_bigint_columns_ge_int128() {
         DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
             "sxt.sxt_tab".parse().unwrap(),
             ident("bigint_column"),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ))),
         DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
         false,
@@ -173,7 +175,7 @@ fn we_can_directly_check_whether_bigint_columns_le_int128() {
         DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
             "sxt.sxt_tab".parse().unwrap(),
             ident("bigint_column"),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ))),
         DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
         true,
@@ -307,7 +309,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar,
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     });
 
@@ -326,7 +328,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar,
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     });
 
@@ -345,7 +347,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_int128_column_eq_decimal_with
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::Int128,
+            "b".parse().unwrap() => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     });
 
@@ -362,7 +364,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_bigint_column_eq_decimal_with
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt,
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         },
     });
 

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,7 +1,8 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
+        database::{
+            ColumnRef, ColumnType, ColumnTypeAssociatedData, LiteralValue, TestSchemaAccessor,
+        },
         map::{indexmap, IndexMap},
         math::decimal::Precision,
     },

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,8 +1,6 @@
 use crate::{
     base::{
-        database::{
-            ColumnRef, ColumnType, ColumnTypeAssociatedData, LiteralValue, TestSchemaAccessor,
-        },
+        database::{ColumnNullability, ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
         map::{indexmap, IndexMap},
         math::decimal::Precision,
     },
@@ -30,7 +28,7 @@ use proof_of_sql_parser::{
 ///   call is expected to succeed; however, if it encounters an invalid precision value, it will
 ///   cause a panic when `unwrap()` is called.
 fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let tab_ref = "sxt.sxt_tab".parse().unwrap();
     let mut column_mapping = IndexMap::default();
     // Setup column mapping
@@ -154,7 +152,7 @@ fn we_can_directly_check_whether_bigint_columns_ge_int128() {
         DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
             "sxt.sxt_tab".parse().unwrap(),
             ident("bigint_column"),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ))),
         DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
         false,
@@ -176,7 +174,7 @@ fn we_can_directly_check_whether_bigint_columns_le_int128() {
         DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
             "sxt.sxt_tab".parse().unwrap(),
             ident("bigint_column"),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ))),
         DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
         true,
@@ -310,7 +308,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     });
 
@@ -329,7 +327,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::VarChar(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::VarChar(ColumnNullability::NotNullable),
         },
     });
 
@@ -348,7 +346,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_int128_column_eq_decimal_with
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::Int128(ColumnNullability::NotNullable),
         },
     });
 
@@ -365,7 +363,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_bigint_column_eq_decimal_with
     let t = "sxt.sxt_tab".parse().unwrap();
     let accessor = TestSchemaAccessor::new(indexmap! {
         t => indexmap! {
-            "b".parse().unwrap() => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            "b".parse().unwrap() => ColumnType::BigInt(ColumnNullability::NotNullable),
         },
     });
 

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
@@ -17,7 +18,6 @@ use proof_of_sql_parser::{
     utility::*,
     Identifier, SelectStatement,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// # Panics
 ///

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -1,4 +1,5 @@
 use super::{PostprocessingError, PostprocessingResult, PostprocessingStep};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{group_by_util::aggregate_columns, Column, OwnedColumn, OwnedTable},
     map::{indexmap, IndexMap, IndexSet},
@@ -12,7 +13,6 @@ use proof_of_sql_parser::{
     Identifier,
 };
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// A group by expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -306,7 +306,7 @@ impl<S: Scalar> PostprocessingStep<S> for GroupByPostprocessing {
         //TODO: When we have NULLs we need to differentiate between count(1) and count(expression)
         let count_column = OwnedColumn::BigInt(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            aggregation_results.count_column.to_vec()
+            aggregation_results.count_column.to_vec(),
         );
         let count_outs = evaluated_columns
             .get(&AggregationOperator::Count)

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -12,6 +12,7 @@ use proof_of_sql_parser::{
     Identifier,
 };
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// A group by expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -303,7 +304,10 @@ impl<S: Scalar> PostprocessingStep<S> for GroupByPostprocessing {
             ))
         });
         //TODO: When we have NULLs we need to differentiate between count(1) and count(expression)
-        let count_column = OwnedColumn::BigInt(aggregation_results.count_column.to_vec());
+        let count_column = OwnedColumn::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            aggregation_results.count_column.to_vec()
+        );
         let count_outs = evaluated_columns
             .get(&AggregationOperator::Count)
             .into_iter()

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -1,7 +1,7 @@
 use super::{PostprocessingError, PostprocessingResult, PostprocessingStep};
 use crate::base::{
     database::{
-        group_by_util::aggregate_columns, Column, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+        group_by_util::aggregate_columns, Column, ColumnNullability, OwnedColumn, OwnedTable,
     },
     map::{indexmap, IndexMap, IndexSet},
     scalar::Scalar,
@@ -306,7 +306,7 @@ impl<S: Scalar> PostprocessingStep<S> for GroupByPostprocessing {
         });
         //TODO: When we have NULLs we need to differentiate between count(1) and count(expression)
         let count_column = OwnedColumn::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             aggregation_results.count_column.to_vec(),
         );
         let count_outs = evaluated_columns

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -1,7 +1,8 @@
 use super::{PostprocessingError, PostprocessingResult, PostprocessingStep};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
-    database::{group_by_util::aggregate_columns, Column, OwnedColumn, OwnedTable},
+    database::{
+        group_by_util::aggregate_columns, Column, ColumnTypeAssociatedData, OwnedColumn, OwnedTable,
+    },
     map::{indexmap, IndexMap, IndexSet},
     scalar::Scalar,
 };

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -17,6 +17,7 @@ use arrow::{
 };
 use curve25519_dalek::RistrettoPoint;
 use num_traits::{One, Zero};
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
@@ -136,13 +137,14 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
 #[cfg(feature = "arrow")]
 #[test]
 fn we_can_form_the_provable_query_result() {
-    let col1: Column<Curve25519Scalar> = Column::BigInt(&[11_i64, 12]);
-    let col2: Column<Curve25519Scalar> = Column::BigInt(&[-3_i64, -4]);
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let col1: Column<Curve25519Scalar> = Column::BigInt(meta, &[11_i64, 12]);
+    let col2: Column<Curve25519Scalar> = Column::BigInt(meta, &[-3_i64, -4]);
     let res = ProvableQueryResult::new(2, &[col1, col2]);
 
     let column_fields = vec![
-        ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
+        ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
     ];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -2,7 +2,7 @@ use super::{FinalRoundBuilder, ProvableQueryResult, SumcheckRandomScalars};
 use crate::{
     base::{
         commitment::{Commitment, CommittableColumn},
-        database::{Column, ColumnField, ColumnType, ColumnTypeAssociatedData},
+        database::{Column, ColumnField, ColumnNullability, ColumnType},
         polynomial::{compute_evaluation_vector, CompositePolynomial, MultilinearExtension},
         scalar::Curve25519Scalar,
     },
@@ -136,7 +136,7 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
 #[cfg(feature = "arrow")]
 #[test]
 fn we_can_form_the_provable_query_result() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let col1: Column<Curve25519Scalar> = Column::BigInt(meta, &[11_i64, 12]);
     let col2: Column<Curve25519Scalar> = Column::BigInt(meta, &[-3_i64, -4]);
     let res = ProvableQueryResult::new(2, &[col1, col2]);

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,9 +1,8 @@
 use super::{FinalRoundBuilder, ProvableQueryResult, SumcheckRandomScalars};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, CommittableColumn},
-        database::{Column, ColumnField, ColumnType},
+        database::{Column, ColumnField, ColumnType, ColumnTypeAssociatedData},
         polynomial::{compute_evaluation_vector, CompositePolynomial, MultilinearExtension},
         scalar::Curve25519Scalar,
     },

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,4 +1,5 @@
 use super::{FinalRoundBuilder, ProvableQueryResult, SumcheckRandomScalars};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, CommittableColumn},
@@ -17,7 +18,6 @@ use arrow::{
 };
 use curve25519_dalek::RistrettoPoint;
 use num_traits::{One, Zero};
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -105,18 +105,18 @@ impl ProvableQueryResult {
             let mut val = S::zero();
             for entry in evaluation_vec.iter().take(output_length) {
                 let (x, sz) = match field.data_type() {
-                    ColumnType::Boolean => decode_and_convert::<bool, S>(&self.data[offset..]),
-                    ColumnType::TinyInt => decode_and_convert::<i8, S>(&self.data[offset..]),
-                    ColumnType::SmallInt => decode_and_convert::<i16, S>(&self.data[offset..]),
-                    ColumnType::Int => decode_and_convert::<i32, S>(&self.data[offset..]),
-                    ColumnType::BigInt => decode_and_convert::<i64, S>(&self.data[offset..]),
-                    ColumnType::Int128 => decode_and_convert::<i128, S>(&self.data[offset..]),
-                    ColumnType::Decimal75(_, _) | ColumnType::Scalar => {
+                    ColumnType::Boolean(_) => decode_and_convert::<bool, S>(&self.data[offset..]),
+                    ColumnType::TinyInt(_) => decode_and_convert::<i8, S>(&self.data[offset..]),
+                    ColumnType::SmallInt(_) => decode_and_convert::<i16, S>(&self.data[offset..]),
+                    ColumnType::Int(_) => decode_and_convert::<i32, S>(&self.data[offset..]),
+                    ColumnType::BigInt(_) => decode_and_convert::<i64, S>(&self.data[offset..]),
+                    ColumnType::Int128(_) => decode_and_convert::<i128, S>(&self.data[offset..]),
+                    ColumnType::Decimal75(_, _, _) | ColumnType::Scalar(_) => {
                         decode_and_convert::<S, S>(&self.data[offset..])
                     }
 
-                    ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
-                    ColumnType::TimestampTZ(_, _) => {
+                    ColumnType::VarChar(_) => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::TimestampTZ(_, _, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
                 }?;
@@ -154,55 +154,55 @@ impl ProvableQueryResult {
             column_result_fields
                 .iter()
                 .map(|field| match field.data_type() {
-                    ColumnType::Boolean => {
+                    ColumnType::Boolean(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Boolean(col)))
+                        Ok((field.name(), OwnedColumn::Boolean(meta, col)))
                     }
-                    ColumnType::TinyInt => {
+                    ColumnType::TinyInt(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::TinyInt(col)))
+                        Ok((field.name(), OwnedColumn::TinyInt(meta, col)))
                     }
-                    ColumnType::SmallInt => {
+                    ColumnType::SmallInt(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::SmallInt(col)))
+                        Ok((field.name(), OwnedColumn::SmallInt(meta, col)))
                     }
-                    ColumnType::Int => {
+                    ColumnType::Int(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Int(col)))
+                        Ok((field.name(), OwnedColumn::Int(meta, col)))
                     }
-                    ColumnType::BigInt => {
+                    ColumnType::BigInt(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::BigInt(col)))
+                        Ok((field.name(), OwnedColumn::BigInt(meta, col)))
                     }
-                    ColumnType::Int128 => {
+                    ColumnType::Int128(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Int128(col)))
+                        Ok((field.name(), OwnedColumn::Int128(meta, col)))
                     }
-                    ColumnType::VarChar => {
+                    ColumnType::VarChar(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::VarChar(col)))
+                        Ok((field.name(), OwnedColumn::VarChar(meta, col)))
                     }
-                    ColumnType::Scalar => {
+                    ColumnType::Scalar(meta) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Scalar(col)))
+                        Ok((field.name(), OwnedColumn::Scalar(meta, col)))
                     }
-                    ColumnType::Decimal75(precision, scale) => {
+                    ColumnType::Decimal75(meta, precision, scale) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Decimal75(precision, scale, col)))
+                        Ok((field.name(), OwnedColumn::Decimal75(meta, precision, scale, col)))
                     }
-                    ColumnType::TimestampTZ(tu, tz) => {
+                    ColumnType::TimestampTZ(meta, tu, tz) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::TimestampTZ(tu, tz, col)))
+                        Ok((field.name(), OwnedColumn::TimestampTZ(meta, tu, tz, col)))
                     }
                 })
                 .collect::<Result<_, QueryError>>()?,

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -197,7 +197,10 @@ impl ProvableQueryResult {
                     ColumnType::Decimal75(meta, precision, scale) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Decimal75(meta, precision, scale, col)))
+                        Ok((
+                            field.name(),
+                            OwnedColumn::Decimal75(meta, precision, scale, col),
+                        ))
                     }
                     ColumnType::TimestampTZ(meta, tu, tz) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -1,6 +1,6 @@
 use super::{ProvableQueryResult, QueryError};
 use crate::base::{
-    database::{Column, ColumnField, ColumnType, ColumnTypeAssociatedData},
+    database::{Column, ColumnField, ColumnNullability, ColumnType},
     math::decimal::Precision,
     polynomial::compute_evaluation_vector,
     scalar::{Curve25519Scalar, Scalar},
@@ -15,14 +15,12 @@ use num_traits::Zero;
 
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[0_i64; 0],
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[0_i64; 0])];
     let res = ProvableQueryResult::new(0, &cols);
     let column_fields = vec![ColumnField::new(
         "a1".parse().unwrap(),
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
     )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
@@ -41,7 +39,7 @@ fn we_can_convert_an_empty_provable_result_to_a_final_result() {
 
 #[test]
 fn we_can_evaluate_result_columns_as_mles() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(meta, &[10, -12])];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
@@ -54,7 +52,7 @@ fn we_can_evaluate_result_columns_as_mles() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         cols.len()
     ];
@@ -69,10 +67,8 @@ fn we_can_evaluate_result_columns_as_mles() {
 
 #[test]
 fn we_can_evaluate_result_columns_with_no_rows() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[0; 0],
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[0; 0])];
     let res = ProvableQueryResult::new(0, &cols);
     let evaluation_point = [];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 0];
@@ -80,7 +76,7 @@ fn we_can_evaluate_result_columns_with_no_rows() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         cols.len()
     ];
@@ -94,8 +90,8 @@ fn we_can_evaluate_result_columns_with_no_rows() {
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles() {
     let cols: [Column<Curve25519Scalar>; 2] = [
-        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
-        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+        Column::BigInt(ColumnNullability::NotNullable, &[10, 12]),
+        Column::BigInt(ColumnNullability::NotNullable, &[5, 9]),
     ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
@@ -107,7 +103,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         cols.len()
     ];
@@ -126,8 +122,8 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
     let cols: [Column<Curve25519Scalar>; 2] = [
-        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
-        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+        Column::Int128(ColumnNullability::NotNullable, &[10, 12]),
+        Column::Int128(ColumnNullability::NotNullable, &[5, 9]),
     ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
@@ -139,7 +135,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int128(ColumnNullability::NotNullable)
         );
         cols.len()
     ];
@@ -158,7 +154,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
 #[allow(clippy::similar_names)]
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let col0 = [10, 12]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
@@ -193,8 +189,8 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
     let cols: [Column<Curve25519Scalar>; 2] = [
-        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
-        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+        Column::BigInt(ColumnNullability::NotNullable, &[10, 12]),
+        Column::Int128(ColumnNullability::NotNullable, &[5, 9]),
     ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
@@ -206,11 +202,11 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
     let column_fields = [
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ),
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::Int128(ColumnNullability::NotNullable),
         ),
     ];
     let evals = res
@@ -227,10 +223,8 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
 
 #[test]
 fn evaluation_fails_if_extra_data_is_included() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[10, 12],
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[10, 12])];
     let mut res = ProvableQueryResult::new(2, &cols);
     res.data_mut().push(3u8);
     let evaluation_point = [
@@ -242,7 +236,7 @@ fn evaluation_fails_if_extra_data_is_included() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         cols.len()
     ];
@@ -265,7 +259,7 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         res.num_columns()
     ];
@@ -278,10 +272,8 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
 #[test]
 fn evaluation_fails_if_integer_overflow_happens() {
     let binding = [i64::from(i32::MAX) + 1_i64, 12];
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &binding,
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &binding)];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -292,7 +284,7 @@ fn evaluation_fails_if_integer_overflow_happens() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ColumnType::Int(ColumnNullability::NotNullable)
         );
         res.num_columns()
     ];
@@ -304,10 +296,8 @@ fn evaluation_fails_if_integer_overflow_happens() {
 
 #[test]
 fn evaluation_fails_if_data_is_missing() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[10, 12],
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[10, 12])];
     let mut res = ProvableQueryResult::new(2, &cols);
     *res.num_columns_mut() = 3;
     let evaluation_point = [
@@ -319,7 +309,7 @@ fn evaluation_fails_if_data_is_missing() {
     let column_fields = vec![
         ColumnField::new(
             "a".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         );
         res.num_columns()
     ];
@@ -331,14 +321,12 @@ fn evaluation_fails_if_data_is_missing() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[10, 12],
-    )];
+    let cols: [Column<Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[10, 12])];
     let res = ProvableQueryResult::new(2, &cols);
     let column_fields = vec![ColumnField::new(
         "a1".parse().unwrap(),
-        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::BigInt(ColumnNullability::NotNullable),
     )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
@@ -358,13 +346,13 @@ fn we_can_convert_a_provable_result_to_a_final_result() {
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
     let cols: [Column<Curve25519Scalar>; 1] = [Column::Int128(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
+        ColumnNullability::NotNullable,
         &[10, i128::MAX],
     )];
     let res = ProvableQueryResult::new(2, &cols);
     let column_fields = vec![ColumnField::new(
         "a1".parse().unwrap(),
-        ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ColumnType::Int128(ColumnNullability::NotNullable),
     )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
@@ -390,7 +378,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let values = [Curve25519Scalar::from(10), Curve25519Scalar::MAX_SIGNED];
 
     let cols: [Column<Curve25519Scalar>; 1] = [Column::Scalar(meta, &values)];
@@ -424,7 +412,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let values1: [i64; 2] = [6, i64::MAX];
     let values2: [i128; 2] = [10, i128::MAX];
     let values3 = ["abc", "de"];

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -12,12 +12,13 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use num_traits::Zero;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[0_i64; 0])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE,  &[0_i64; 0])];
     let res = ProvableQueryResult::new(0, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)];
+    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),)];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),
@@ -35,7 +36,8 @@ fn we_can_convert_an_empty_provable_result_to_a_final_result() {
 
 #[test]
 fn we_can_evaluate_result_columns_as_mles() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[10, -12])];
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(meta, &[10, -12])];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -45,7 +47,7 @@ fn we_can_evaluate_result_columns_as_mles() {
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
 
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -57,13 +59,13 @@ fn we_can_evaluate_result_columns_as_mles() {
 
 #[test]
 fn we_can_evaluate_result_columns_with_no_rows() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[0; 0])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[0; 0])];
     let res = ProvableQueryResult::new(0, &cols);
     let evaluation_point = [];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 0];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
     let evals = res
         .evaluate(&evaluation_point, 0, &column_fields[..])
         .unwrap();
@@ -73,7 +75,7 @@ fn we_can_evaluate_result_columns_with_no_rows() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(&[10, 12]), Column::BigInt(&[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -82,7 +84,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -97,7 +99,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::Int128(&[10, 12]), Column::Int128(&[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -106,7 +108,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int128); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)); cols.len()];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -122,6 +124,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
 #[allow(clippy::similar_names)]
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let col0 = [10, 12]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
@@ -130,7 +133,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::Scalar(&col0), Column::Scalar(&col1)];
+    let cols: [Column<Curve25519Scalar>; 2] = [Column::Scalar(meta, &col0), Column::Scalar(meta, &col1)];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -139,7 +142,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Scalar); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Scalar(meta)); cols.len()];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -154,7 +157,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(&[10, 12]), Column::Int128(&[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -163,8 +166,8 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields = [
-        ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("a".parse().unwrap(), ColumnType::Int128),
+        ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),),
+        ColumnField::new("a".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),),
     ];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
@@ -180,7 +183,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
 
 #[test]
 fn evaluation_fails_if_extra_data_is_included() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
     let mut res = ProvableQueryResult::new(2, &cols);
     res.data_mut().push(3u8);
     let evaluation_point = [
@@ -190,7 +193,7 @@ fn evaluation_fails_if_extra_data_is_included() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); cols.len()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::MiscellaneousEvaluationError)
@@ -208,7 +211,7 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); res.num_columns()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); res.num_columns()];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -218,7 +221,7 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
 #[test]
 fn evaluation_fails_if_integer_overflow_happens() {
     let binding = [i64::from(i32::MAX) + 1_i64, 12];
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&binding)];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &binding)];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -227,7 +230,7 @@ fn evaluation_fails_if_integer_overflow_happens() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int); res.num_columns()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)); res.num_columns()];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -236,7 +239,7 @@ fn evaluation_fails_if_integer_overflow_happens() {
 
 #[test]
 fn evaluation_fails_if_data_is_missing() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
     let mut res = ProvableQueryResult::new(2, &cols);
     *res.num_columns_mut() = 3;
     let evaluation_point = [
@@ -246,7 +249,7 @@ fn evaluation_fails_if_data_is_missing() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt); res.num_columns()];
+        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); res.num_columns()];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -255,9 +258,9 @@ fn evaluation_fails_if_data_is_missing() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(&[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
     let res = ProvableQueryResult::new(2, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)];
+    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),)];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),
@@ -275,9 +278,9 @@ fn we_can_convert_a_provable_result_to_a_final_result() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::Int128(&[10, i128::MAX])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, i128::MAX])];
     let res = ProvableQueryResult::new(2, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::Int128)];
+    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE))];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),
@@ -302,13 +305,14 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let values = [Curve25519Scalar::from(10), Curve25519Scalar::MAX_SIGNED];
 
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::Scalar(&values)];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::Scalar(meta, &values)];
     let res = ProvableQueryResult::new(2, &cols);
     let column_fields = vec![ColumnField::new(
         "a1".parse().unwrap(),
-        ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+        ColumnType::Decimal75(meta, Precision::new(75).unwrap(), 0),
     )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
@@ -335,6 +339,7 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_252_bits() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let values1: [i64; 2] = [6, i64::MAX];
     let values2: [i128; 2] = [10, i128::MAX];
     let values3 = ["abc", "de"];
@@ -345,19 +350,19 @@ fn we_can_convert_a_provable_result_to_a_final_result_with_mixed_data_types() {
     let values4 = [Curve25519Scalar::from(10), Curve25519Scalar::MAX_SIGNED];
 
     let cols: [Column<Curve25519Scalar>; 4] = [
-        Column::BigInt(&values1),
-        Column::Int128(&values2),
-        Column::VarChar((&values3, &scalars3)),
-        Column::Scalar(&values4),
+        Column::BigInt(meta, &values1),
+        Column::Int128(meta, &values2),
+        Column::VarChar(meta, (&values3, &scalars3)),
+        Column::Scalar(meta, &values4),
     ];
     let res = ProvableQueryResult::new(2, &cols);
     let column_fields = vec![
-        ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("a2".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("a3".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("a2".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("a3".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "a4".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(75).unwrap(), 0),
         ),
     ];
     let res = RecordBatch::try_from(

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -1,4 +1,5 @@
 use super::{ProvableQueryResult, QueryError};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     database::{Column, ColumnField, ColumnType},
     math::decimal::Precision,
@@ -12,13 +13,18 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use num_traits::Zero;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE,  &[0_i64; 0])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[0_i64; 0],
+    )];
     let res = ProvableQueryResult::new(0, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),)];
+    let column_fields = vec![ColumnField::new(
+        "a1".parse().unwrap(),
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+    )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),
@@ -46,8 +52,13 @@ fn we_can_evaluate_result_columns_as_mles() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
 
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        cols.len()
+    ];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -59,13 +70,21 @@ fn we_can_evaluate_result_columns_as_mles() {
 
 #[test]
 fn we_can_evaluate_result_columns_with_no_rows() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[0; 0])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[0; 0],
+    )];
     let res = ProvableQueryResult::new(0, &cols);
     let evaluation_point = [];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 0];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        cols.len()
+    ];
     let evals = res
         .evaluate(&evaluation_point, 0, &column_fields[..])
         .unwrap();
@@ -75,7 +94,10 @@ fn we_can_evaluate_result_columns_with_no_rows() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [
+        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
+        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+    ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -83,8 +105,13 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        cols.len()
+    ];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -99,7 +126,10 @@ fn we_can_evaluate_multiple_result_columns_as_mles() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [
+        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
+        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+    ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -107,8 +137,13 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)); cols.len()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
+        cols.len()
+    ];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
@@ -133,7 +168,8 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::Scalar(meta, &col0), Column::Scalar(meta, &col1)];
+    let cols: [Column<Curve25519Scalar>; 2] =
+        [Column::Scalar(meta, &col0), Column::Scalar(meta, &col1)];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -157,7 +193,10 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
 
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
-    let cols: [Column<Curve25519Scalar>; 2] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]), Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9])];
+    let cols: [Column<Curve25519Scalar>; 2] = [
+        Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12]),
+        Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[5, 9]),
+    ];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -166,8 +205,14 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
     let column_fields = [
-        ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),),
-        ColumnField::new("a".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),),
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ),
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+        ),
     ];
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
@@ -183,7 +228,10 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_mixed_data_types() {
 
 #[test]
 fn evaluation_fails_if_extra_data_is_included() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[10, 12],
+    )];
     let mut res = ProvableQueryResult::new(2, &cols);
     res.data_mut().push(3u8);
     let evaluation_point = [
@@ -192,8 +240,13 @@ fn evaluation_fails_if_extra_data_is_included() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); cols.len()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        cols.len()
+    ];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::MiscellaneousEvaluationError)
@@ -210,8 +263,13 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); res.num_columns()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        res.num_columns()
+    ];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -221,7 +279,10 @@ fn evaluation_fails_if_the_result_cant_be_decoded() {
 #[test]
 fn evaluation_fails_if_integer_overflow_happens() {
     let binding = [i64::from(i32::MAX) + 1_i64, 12];
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &binding)];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &binding,
+    )];
     let res = ProvableQueryResult::new(2, &cols);
     let evaluation_point = [
         Curve25519Scalar::from(10u64),
@@ -229,8 +290,13 @@ fn evaluation_fails_if_integer_overflow_happens() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)); res.num_columns()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::Int(ColumnTypeAssociatedData::NOT_NULLABLE)
+        );
+        res.num_columns()
+    ];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -239,7 +305,10 @@ fn evaluation_fails_if_integer_overflow_happens() {
 
 #[test]
 fn evaluation_fails_if_data_is_missing() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[10, 12],
+    )];
     let mut res = ProvableQueryResult::new(2, &cols);
     *res.num_columns_mut() = 3;
     let evaluation_point = [
@@ -248,8 +317,13 @@ fn evaluation_fails_if_data_is_missing() {
     ];
     let mut evaluation_vec = [Curve25519Scalar::ZERO; 2];
     compute_evaluation_vector(&mut evaluation_vec, &evaluation_point);
-    let column_fields =
-        vec![ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),); res.num_columns()];
+    let column_fields = vec![
+        ColumnField::new(
+            "a".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        );
+        res.num_columns()
+    ];
     assert!(matches!(
         res.evaluate(&evaluation_point, 2, &column_fields[..]),
         Err(QueryError::Overflow)
@@ -258,9 +332,15 @@ fn evaluation_fails_if_data_is_missing() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, 12])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[10, 12],
+    )];
     let res = ProvableQueryResult::new(2, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),)];
+    let column_fields = vec![ColumnField::new(
+        "a1".parse().unwrap(),
+        ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+    )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),
@@ -278,9 +358,15 @@ fn we_can_convert_a_provable_result_to_a_final_result() {
 
 #[test]
 fn we_can_convert_a_provable_result_to_a_final_result_with_128_bits() {
-    let cols: [Column<Curve25519Scalar>; 1] = [Column::Int128(ColumnTypeAssociatedData::NOT_NULLABLE, &[10, i128::MAX])];
+    let cols: [Column<Curve25519Scalar>; 1] = [Column::Int128(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[10, i128::MAX],
+    )];
     let res = ProvableQueryResult::new(2, &cols);
-    let column_fields = vec![ColumnField::new("a1".parse().unwrap(), ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE))];
+    let column_fields = vec![ColumnField::new(
+        "a1".parse().unwrap(),
+        ColumnType::Int128(ColumnTypeAssociatedData::NOT_NULLABLE),
+    )];
     let res = RecordBatch::try_from(
         res.to_owned_table::<Curve25519Scalar>(&column_fields)
             .unwrap(),

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -1,7 +1,6 @@
 use super::{ProvableQueryResult, QueryError};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
-    database::{Column, ColumnField, ColumnType},
+    database::{Column, ColumnField, ColumnType, ColumnTypeAssociatedData},
     math::decimal::Precision,
     polynomial::compute_evaluation_vector,
     scalar::{Curve25519Scalar, Scalar},

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -30,27 +30,27 @@ impl<'a, T: ProvableResultElement<'a>> ProvableResultColumn for &[T] {
 impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn num_bytes(&self, length: u64) -> usize {
         match self {
-            Column::Boolean(col) => col.num_bytes(length),
-            Column::TinyInt(col) => col.num_bytes(length),
-            Column::SmallInt(col) => col.num_bytes(length),
-            Column::Int(col) => col.num_bytes(length),
-            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col.num_bytes(length),
-            Column::Int128(col) => col.num_bytes(length),
-            Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(length),
-            Column::VarChar((col, _)) => col.num_bytes(length),
+            Column::Boolean(_, col) => col.num_bytes(length),
+            Column::TinyInt(_, col) => col.num_bytes(length),
+            Column::SmallInt(_, col) => col.num_bytes(length),
+            Column::Int(_, col) => col.num_bytes(length),
+            Column::BigInt(_, col) | Column::TimestampTZ(.., col) => col.num_bytes(length),
+            Column::Int128(_, col) => col.num_bytes(length),
+            Column::Decimal75(_, _, _, col) | Column::Scalar(_, col) => col.num_bytes(length),
+            Column::VarChar(_, (col, _)) => col.num_bytes(length),
         }
     }
 
     fn write(&self, out: &mut [u8], length: u64) -> usize {
         match self {
-            Column::Boolean(col) => col.write(out, length),
-            Column::TinyInt(col) => col.write(out, length),
-            Column::SmallInt(col) => col.write(out, length),
-            Column::Int(col) => col.write(out, length),
-            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col.write(out, length),
-            Column::Int128(col) => col.write(out, length),
-            Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, length),
-            Column::VarChar((col, _)) => col.write(out, length),
+            Column::Boolean(_, col) => col.write(out, length),
+            Column::TinyInt(_, col) => col.write(out, length),
+            Column::SmallInt(_, col) => col.write(out, length),
+            Column::Int(_, col) => col.write(out, length),
+            Column::BigInt(_, col) | Column::TimestampTZ(.., col) => col.write(out, length),
+            Column::Int128(_, col) => col.write(out, length),
+            Column::Decimal75(.., col) | Column::Scalar(_, col) => col.write(out, length),
+            Column::VarChar(_, (col, _)) => col.write(out, length),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -1,15 +1,14 @@
 use super::{
     CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, QueryProof, VerificationBuilder,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TestAccessor,
-            UnimplementedTestAccessor,
+            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable, OwnedTableTestAccessor,
+            TestAccessor, UnimplementedTestAccessor,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -1,6 +1,7 @@
 use super::{
     CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, QueryProof, VerificationBuilder,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, InnerProductProof},
@@ -18,7 +19,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Type to allow us to prove and verify an artificial polynomial where we prove
 /// that every entry in the result is zero
@@ -105,7 +105,10 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
     ///
     /// This method will panic if the `ColumnField` cannot be created from the provided column name (e.g., if the name parsing fails).
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
+        vec![ColumnField::new(
+            "a1".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -274,7 +277,10 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
+        vec![ColumnField::new(
+            "a1".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -477,7 +483,10 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
+        vec![ColumnField::new(
+            "a1".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -599,7 +608,10 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[9, 25])]
+        vec![Column::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[9, 25],
+        )]
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -629,7 +641,10 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
                 (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[9, 25])]
+        vec![Column::BigInt(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            &[9, 25],
+        )]
     }
 }
 impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
@@ -673,7 +688,10 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
+        vec![ColumnField::new(
+            "a1".parse().unwrap(),
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+        )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -6,9 +6,9 @@ use crate::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
-            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable, OwnedTableTestAccessor,
-            TestAccessor, UnimplementedTestAccessor,
+            Column, ColumnField, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor,
+            DataAccessor, MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TestAccessor,
+            UnimplementedTestAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -48,7 +48,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, col)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, col)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -65,7 +65,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
             SumcheckSubpolynomialType::Identity,
             vec![(S::ONE, vec![Box::new(col as &[_])])],
         );
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, col)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, col)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
@@ -106,7 +106,7 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
             "a1".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -208,7 +208,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -222,7 +222,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         builder.produce_anchored_mle(x);
@@ -234,7 +234,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
                 (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
@@ -265,7 +265,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
             * accessor.get_commitment(ColumnRef::new(
                 "sxt.test".parse().unwrap(),
                 "x".parse().unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                ColumnType::BigInt(ColumnNullability::NotNullable),
             ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let res_eval = builder.consume_intermediate_mle();
@@ -278,7 +278,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
             "a1".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -393,7 +393,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -407,7 +407,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         let z: &[_] = alloc.alloc_slice_copy(&self.z);
@@ -432,7 +432,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
             ],
         );
         builder.produce_intermediate_mle(res);
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
@@ -462,7 +462,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         let x_commit = accessor.get_commitment(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let z_eval = builder.consume_intermediate_mle();
@@ -484,7 +484,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
             "a1".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
@@ -607,10 +607,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        vec![Column::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            &[9, 25],
-        )]
+        vec![Column::BigInt(ColumnNullability::NotNullable, &[9, 25])]
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -626,7 +623,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&[9, 25]);
         let alpha = builder.consume_post_result_challenge();
@@ -640,10 +637,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
                 (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
-            &[9, 25],
-        )]
+        vec![Column::BigInt(ColumnNullability::NotNullable, &[9, 25])]
     }
 }
 impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
@@ -676,7 +670,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         let x_commit = accessor.get_commitment(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let res_eval = builder.consume_intermediate_mle();
@@ -689,7 +683,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new(
             "a1".parse().unwrap(),
-            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            ColumnType::BigInt(ColumnNullability::NotNullable),
         )]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Type to allow us to prove and verify an artificial polynomial where we prove
 /// that every entry in the result is zero
@@ -48,7 +49,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
-        vec![Column::BigInt(col)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, col)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -65,7 +66,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
             SumcheckSubpolynomialType::Identity,
             vec![(S::ONE, vec![Box::new(col as &[_])])],
         );
-        vec![Column::BigInt(col)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, col)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
@@ -104,7 +105,7 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
     ///
     /// This method will panic if the `ColumnField` cannot be created from the provided column name (e.g., if the name parsing fails).
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
+        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -205,7 +206,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(res)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -219,7 +220,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         builder.produce_anchored_mle(x);
@@ -231,7 +232,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
                 (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(res)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
@@ -262,7 +263,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
             * accessor.get_commitment(ColumnRef::new(
                 "sxt.test".parse().unwrap(),
                 "x".parse().unwrap(),
-                ColumnType::BigInt,
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
             ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let res_eval = builder.consume_intermediate_mle();
@@ -273,7 +274,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
+        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -387,7 +388,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(res)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -401,7 +402,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         let z: &[_] = alloc.alloc_slice_copy(&self.z);
@@ -426,7 +427,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
             ],
         );
         builder.produce_intermediate_mle(res);
-        vec![Column::BigInt(res)]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res)]
     }
 }
 impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
@@ -456,7 +457,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         let x_commit = accessor.get_commitment(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let z_eval = builder.consume_intermediate_mle();
@@ -476,7 +477,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
+        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
@@ -598,7 +599,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        vec![Column::BigInt(&[9, 25])]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[9, 25])]
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -614,7 +615,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ));
         let res: &[_] = alloc.alloc_slice_copy(&[9, 25]);
         let alpha = builder.consume_post_result_challenge();
@@ -628,7 +629,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
                 (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(&[9, 25])]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[9, 25])]
     }
 }
 impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
@@ -661,7 +662,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         let x_commit = accessor.get_commitment(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
-            ColumnType::BigInt,
+            ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
         ));
         let x_eval = builder.consume_anchored_mle(x_commit);
         let res_eval = builder.consume_intermediate_mle();
@@ -672,7 +673,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
-        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
+        vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -169,8 +169,9 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                         }
                         ColumnType::Scalar(meta) => OwnedColumn::Scalar(meta, vec![]),
                         ColumnType::VarChar(meta) => OwnedColumn::VarChar(meta, vec![]),
-                        ColumnType::TimestampTZ(meta, tu, tz) =>
-                            OwnedColumn::TimestampTZ(meta, tu, tz, vec![]),
+                        ColumnType::TimestampTZ(meta, tu, tz) => {
+                            OwnedColumn::TimestampTZ(meta, tu, tz, vec![])
+                        }
                     },
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -158,18 +158,19 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                 (
                     field.name(),
                     match field.data_type() {
-                        ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
-                        ColumnType::TinyInt => OwnedColumn::TinyInt(vec![]),
-                        ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
-                        ColumnType::Int => OwnedColumn::Int(vec![]),
-                        ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
-                        ColumnType::Int128 => OwnedColumn::Int128(vec![]),
-                        ColumnType::Decimal75(precision, scale) => {
-                            OwnedColumn::Decimal75(precision, scale, vec![])
+                        ColumnType::Boolean(meta) => OwnedColumn::Boolean(meta, vec![]),
+                        ColumnType::TinyInt(meta) => OwnedColumn::TinyInt(meta, vec![]),
+                        ColumnType::SmallInt(meta) => OwnedColumn::SmallInt(meta, vec![]),
+                        ColumnType::Int(meta) => OwnedColumn::Int(meta, vec![]),
+                        ColumnType::BigInt(meta) => OwnedColumn::BigInt(meta, vec![]),
+                        ColumnType::Int128(meta) => OwnedColumn::Int128(meta, vec![]),
+                        ColumnType::Decimal75(meta, precision, scale) => {
+                            OwnedColumn::Decimal75(meta, precision, scale, vec![])
                         }
-                        ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
-                        ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
-                        ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
+                        ColumnType::Scalar(meta) => OwnedColumn::Scalar(meta, vec![]),
+                        ColumnType::VarChar(meta) => OwnedColumn::VarChar(meta, vec![]),
+                        ColumnType::TimestampTZ(meta, tu, tz) =>
+                            OwnedColumn::TimestampTZ(meta, tu, tz, vec![]),
                     },
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -2,6 +2,7 @@ use super::{
     CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, VerifiableQueryResult,
     VerificationBuilder,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, InnerProductProof},
@@ -18,7 +19,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[derive(Debug, Serialize, Default)]
 pub(super) struct EmptyTestQueryExpr {
@@ -82,7 +82,12 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         (1..=self.columns)
-            .map(|i| ColumnField::new(format!("a{i}").parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)))
+            .map(|i| {
+                ColumnField::new(
+                    format!("a{i}").parse().unwrap(),
+                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                )
+            })
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[derive(Debug, Serialize, Default)]
 pub(super) struct EmptyTestQueryExpr {
@@ -33,7 +34,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     ) -> Vec<Column<'a, S>> {
         let zeros = vec![0; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);
-        vec![Column::BigInt(res); self.columns]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res); self.columns]
     }
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
     fn final_round_evaluate<'a>(
@@ -47,7 +48,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
         let _ = std::iter::repeat_with(|| builder.produce_intermediate_mle(res))
             .take(self.columns)
             .collect::<Vec<_>>();
-        vec![Column::BigInt(res); self.columns]
+        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res); self.columns]
     }
 }
 impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
@@ -81,7 +82,7 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         (1..=self.columns)
-            .map(|i| ColumnField::new(format!("a{i}").parse().unwrap(), ColumnType::BigInt))
+            .map(|i| ColumnField::new(format!("a{i}").parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)))
             .collect()
     }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,9 +7,8 @@ use crate::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
-            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable, TestAccessor,
-            UnimplementedTestAccessor,
+            Column, ColumnField, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor,
+            DataAccessor, MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -34,7 +33,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     ) -> Vec<Column<'a, S>> {
         let zeros = vec![0; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res); self.columns]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res); self.columns]
     }
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
     fn final_round_evaluate<'a>(
@@ -48,7 +47,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
         let _ = std::iter::repeat_with(|| builder.produce_intermediate_mle(res))
             .take(self.columns)
             .collect::<Vec<_>>();
-        vec![Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, res); self.columns]
+        vec![Column::BigInt(ColumnNullability::NotNullable, res); self.columns]
     }
 }
 impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
@@ -85,7 +84,7 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
             .map(|i| {
                 ColumnField::new(
                     format!("a{i}").parse().unwrap(),
-                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                    ColumnType::BigInt(ColumnNullability::NotNullable),
                 )
             })
             .collect()

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -2,14 +2,14 @@ use super::{
     CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, VerifiableQueryResult,
     VerificationBuilder,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
+            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable, TestAccessor,
+            UnimplementedTestAccessor,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -11,6 +11,7 @@ use blitzar::proof::InnerProductProof;
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
 use num_traits::One;
 use serde::Serialize;
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// This function takes a valid `verifiable_result`, copies it, tweaks it, and checks that
 /// verification fails.
@@ -92,7 +93,7 @@ fn tamper_no_result(
 ) {
     // add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(&[0_i64; 0])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[0_i64; 0])];
     res_p.provable_result = Some(ProvableQueryResult::new(0, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
@@ -115,7 +116,7 @@ fn tamper_empty_result(
 ) {
     // try to add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(&[123_i64])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[123_i64])];
     res_p.provable_result = Some(ProvableQueryResult::new(1, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -2,6 +2,7 @@ use super::{
     verifiable_query_result_test::EmptyTestQueryExpr, ProofPlan, ProvableQueryResult, QueryProof,
     VerifiableQueryResult,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
     database::{Column, CommitmentAccessor, OwnedTableTestAccessor, TableRef, TestAccessor},
@@ -11,7 +12,6 @@ use blitzar::proof::InnerProductProof;
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
 use num_traits::One;
 use serde::Serialize;
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// This function takes a valid `verifiable_result`, copies it, tweaks it, and checks that
 /// verification fails.
@@ -93,7 +93,10 @@ fn tamper_no_result(
 ) {
     // add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[0_i64; 0])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[0_i64; 0],
+    )];
     res_p.provable_result = Some(ProvableQueryResult::new(0, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
@@ -116,7 +119,10 @@ fn tamper_empty_result(
 ) {
     // try to add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, &[123_i64])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[123_i64],
+    )];
     res_p.provable_result = Some(ProvableQueryResult::new(1, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
     database::{
-        Column, ColumnTypeAssociatedData, CommitmentAccessor, OwnedTableTestAccessor, TableRef,
+        Column, ColumnNullability, CommitmentAccessor, OwnedTableTestAccessor, TableRef,
         TestAccessor,
     },
     scalar::Curve25519Scalar,
@@ -95,10 +95,8 @@ fn tamper_no_result(
 ) {
     // add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[0_i64; 0],
-    )];
+    let cols: [Column<'_, Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[0_i64; 0])];
     res_p.provable_result = Some(ProvableQueryResult::new(0, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
@@ -121,10 +119,8 @@ fn tamper_empty_result(
 ) {
     // try to add a result
     let mut res_p = res.clone();
-    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[123_i64],
-    )];
+    let cols: [Column<'_, Curve25519Scalar>; 1] =
+        [Column::BigInt(ColumnNullability::NotNullable, &[123_i64])];
     res_p.provable_result = Some(ProvableQueryResult::new(1, &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -2,10 +2,12 @@ use super::{
     verifiable_query_result_test::EmptyTestQueryExpr, ProofPlan, ProvableQueryResult, QueryProof,
     VerifiableQueryResult,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
-    database::{Column, CommitmentAccessor, OwnedTableTestAccessor, TableRef, TestAccessor},
+    database::{
+        Column, ColumnTypeAssociatedData, CommitmentAccessor, OwnedTableTestAccessor, TableRef,
+        TestAccessor,
+    },
     scalar::Curve25519Scalar,
 };
 use blitzar::proof::InnerProductProof;

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            try_add_subtract_column_types, Column, ColumnNullability, ColumnRef, ColumnType,
             CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
@@ -63,7 +63,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
         Column::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             add_subtract_columns(
                 lhs_column,
                 rhs_column,
@@ -89,7 +89,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
         let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
         Column::Scalar(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             add_subtract_columns(
                 lhs_column,
                 rhs_column,

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -1,11 +1,10 @@
 use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
         database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
+            try_add_subtract_column_types, Column, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -63,7 +63,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
             self.lhs.result_evaluate(table_length, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
-        Column::Scalar(ColumnTypeAssociatedData::default(), add_subtract_columns(
+        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, add_subtract_columns(
             lhs_column,
             rhs_column,
             self.lhs.data_type().scale().unwrap_or(0),
@@ -86,7 +86,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
     ) -> Column<'a, C::Scalar> {
         let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
-        Column::Scalar(ColumnTypeAssociatedData::default(),add_subtract_columns(
+        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE,add_subtract_columns(
             lhs_column,
             rhs_column,
             self.lhs.data_type().scale().unwrap_or(0),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -15,6 +15,7 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable numerical `+` / `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -62,7 +63,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
             self.lhs.result_evaluate(table_length, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
-        Column::Scalar(add_subtract_columns(
+        Column::Scalar(ColumnTypeAssociatedData::default(), add_subtract_columns(
             lhs_column,
             rhs_column,
             self.lhs.data_type().scale().unwrap_or(0),
@@ -85,7 +86,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
     ) -> Column<'a, C::Scalar> {
         let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
-        Column::Scalar(add_subtract_columns(
+        Column::Scalar(ColumnTypeAssociatedData::default(),add_subtract_columns(
             lhs_column,
             rhs_column,
             self.lhs.data_type().scale().unwrap_or(0),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -1,4 +1,5 @@
 use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -15,7 +16,6 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable numerical `+` / `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -63,14 +63,17 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
             self.lhs.result_evaluate(table_length, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
-        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, add_subtract_columns(
-            lhs_column,
-            rhs_column,
-            self.lhs.data_type().scale().unwrap_or(0),
-            self.rhs.data_type().scale().unwrap_or(0),
-            alloc,
-            self.is_subtract,
-        ))
+        Column::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            add_subtract_columns(
+                lhs_column,
+                rhs_column,
+                self.lhs.data_type().scale().unwrap_or(0),
+                self.rhs.data_type().scale().unwrap_or(0),
+                alloc,
+                self.is_subtract,
+            ),
+        )
     }
 
     #[tracing::instrument(
@@ -86,14 +89,17 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
     ) -> Column<'a, C::Scalar> {
         let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
         let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
-        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE,add_subtract_columns(
-            lhs_column,
-            rhs_column,
-            self.lhs.data_type().scale().unwrap_or(0),
-            self.rhs.data_type().scale().unwrap_or(0),
-            alloc,
-            self.is_subtract,
-        ))
+        Column::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            add_subtract_columns(
+                lhs_column,
+                rhs_column,
+                self.lhs.data_type().scale().unwrap_or(0),
+                self.rhs.data_type().scale().unwrap_or(0),
+                alloc,
+                self.is_subtract,
+            ),
+        )
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -19,6 +19,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 // select a, c, b + 4 as res, d from sxt.t where a - b = 3
 #[test]
@@ -322,6 +323,6 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(&expected_res_scalar);
+    let expected_res = Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &expected_res_scalar);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,9 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-        },
+        database::{owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor},
         scalar::Curve25519Scalar,
     },
     sql::{
@@ -324,6 +322,6 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &expected_res_scalar);
+    let expected_res = Column::Scalar(ColumnNullability::NotNullable, &expected_res_scalar);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,8 +1,9 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+        },
         scalar::Curve25519Scalar,
     },
     sql::{

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -19,7 +20,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 // select a, c, b + 4 as res, d from sxt.t where a - b = 3
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -12,6 +12,7 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable aggregate expression
 ///
@@ -36,7 +37,7 @@ impl<C: Commitment> ProofExpr<C> for AggregateExpr<C> {
 
     fn data_type(&self) -> ColumnType {
         match self.op {
-            AggregationOperator::Count => ColumnType::BigInt,
+            AggregationOperator::Count => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
             AggregationOperator::Sum => self.expr.data_type(),
             _ => todo!("Aggregation operator not supported here yet"),
         }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -39,9 +38,7 @@ impl<C: Commitment> ProofExpr<C> for AggregateExpr<C> {
 
     fn data_type(&self) -> ColumnType {
         match self.op {
-            AggregationOperator::Count => {
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
-            }
+            AggregationOperator::Count => ColumnType::BigInt(ColumnNullability::NotNullable),
             AggregationOperator::Sum => self.expr.data_type(),
             _ => todo!("Aggregation operator not supported here yet"),
         }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -12,7 +13,6 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable aggregate expression
 ///
@@ -37,7 +37,9 @@ impl<C: Commitment> ProofExpr<C> for AggregateExpr<C> {
 
     fn data_type(&self) -> ColumnType {
         match self.op {
-            AggregationOperator::Count => ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+            AggregationOperator::Count => {
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            }
             AggregationOperator::Sum => self.expr.data_type(),
             _ => todo!("Aggregation operator not supported here yet"),
         }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -1,9 +1,11 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -12,6 +12,7 @@ use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -38,7 +39,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean
+        ColumnType::Boolean(ColumnTypeAssociatedData::default())
     }
 
     #[tracing::instrument(name = "AndExpr::result_evaluate", level = "debug", skip_all)]
@@ -54,7 +55,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
             self.rhs.result_evaluate(table_length, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
+        Column::Boolean(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
     }
 
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
@@ -83,7 +84,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
                 (-C::Scalar::one(), vec![Box::new(lhs), Box::new(rhs)]),
             ],
         );
-        Column::Boolean(lhs_and_rhs)
+        Column::Boolean(ColumnTypeAssociatedData::default(), lhs_and_rhs)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -39,7 +39,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::default())
+        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
     }
 
     #[tracing::instrument(name = "AndExpr::result_evaluate", level = "debug", skip_all)]
@@ -55,7 +55,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
             self.rhs.result_evaluate(table_length, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(ColumnTypeAssociatedData::default(), alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
+        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
     }
 
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
@@ -84,7 +84,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
                 (-C::Scalar::one(), vec![Box::new(lhs), Box::new(rhs)]),
             ],
         );
-        Column::Boolean(ColumnTypeAssociatedData::default(), lhs_and_rhs)
+        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, lhs_and_rhs)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,9 +1,11 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -12,7 +13,6 @@ use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -55,7 +55,10 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
             self.rhs.result_evaluate(table_length, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
+        Column::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]),
+        )
     }
 
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -41,7 +40,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        ColumnType::Boolean(ColumnNullability::NotNullable)
     }
 
     #[tracing::instrument(name = "AndExpr::result_evaluate", level = "debug", skip_all)]
@@ -58,7 +57,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]),
         )
     }
@@ -89,7 +88,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
                 (-C::Scalar::one(), vec![Box::new(lhs), Box::new(rhs)]),
             ],
         );
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, lhs_and_rhs)
+        Column::Boolean(ColumnNullability::NotNullable, lhs_and_rhs)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -17,7 +18,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_simple_and_query() {
@@ -162,6 +162,9 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, false, false]);
+    let expected_res = Column::Boolean(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[false, true, false, false],
+    );
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,8 +1,9 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -17,6 +17,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_simple_and_query() {
@@ -161,6 +162,6 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, false, false]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, false, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,9 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-        },
+        database::{owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor},
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -163,9 +161,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[false, true, false, false],
-    );
+    let expected_res =
+        Column::Boolean(ColumnNullability::NotNullable, &[false, true, false, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -19,6 +19,7 @@ use bumpalo::Bump;
 use core::fmt::Debug;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -51,19 +52,19 @@ impl<C: Commitment> DynProofExpr<C> {
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean)?;
-        rhs.check_data_type(ColumnType::Boolean)?;
+        lhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
+        rhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
         Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical OR expression
     pub fn try_new_or(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean)?;
-        rhs.check_data_type(ColumnType::Boolean)?;
+        lhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
+        rhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
         Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical NOT expression
     pub fn try_new_not(expr: DynProofExpr<C>) -> ConversionResult<Self> {
-        expr.check_data_type(ColumnType::Boolean)?;
+        expr.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
@@ -207,7 +208,7 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
             | DynProofExpr::Or(_)
             | DynProofExpr::Not(_)
             | DynProofExpr::Equals(_)
-            | DynProofExpr::Inequality(_) => ColumnType::Boolean,
+            | DynProofExpr::Inequality(_) => ColumnType::Boolean(ColumnTypeAssociatedData::default()),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -6,8 +6,8 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor, LiteralValue,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
+            LiteralValue,
         },
         map::IndexSet,
         proof::ProofError,
@@ -54,19 +54,19 @@ impl<C: Commitment> DynProofExpr<C> {
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
-        rhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
+        lhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
+        rhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
         Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical OR expression
     pub fn try_new_or(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
-        rhs.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
+        lhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
+        rhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
         Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical NOT expression
     pub fn try_new_not(expr: DynProofExpr<C>) -> ConversionResult<Self> {
-        expr.check_data_type(ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE))?;
+        expr.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
@@ -210,9 +210,7 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
             | DynProofExpr::Or(_)
             | DynProofExpr::Not(_)
             | DynProofExpr::Equals(_)
-            | DynProofExpr::Inequality(_) => {
-                ColumnType::Boolean(ColumnTypeAssociatedData::default())
-            }
+            | DynProofExpr::Inequality(_) => ColumnType::Boolean(ColumnNullability::default()),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -2,6 +2,7 @@ use super::{
     AddSubtractExpr, AggregateExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
     MultiplyExpr, NotExpr, OrExpr, ProofExpr,
 };
+use crate::base::database::ColumnTypeKind;
 use crate::{
     base::{
         commitment::Commitment,
@@ -54,19 +55,19 @@ impl<C: Commitment> DynProofExpr<C> {
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
-        rhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
+        lhs.check_data_type_kind(ColumnTypeKind::Boolean)?;
+        rhs.check_data_type_kind(ColumnTypeKind::Boolean)?;
         Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical OR expression
     pub fn try_new_or(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
-        rhs.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
+        lhs.check_data_type_kind(ColumnTypeKind::Boolean)?;
+        rhs.check_data_type_kind(ColumnTypeKind::Boolean)?;
         Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical NOT expression
     pub fn try_new_not(expr: DynProofExpr<C>) -> ConversionResult<Self> {
-        expr.check_data_type(ColumnType::Boolean(ColumnNullability::NotNullable))?;
+        expr.check_data_type_kind(ColumnTypeKind::Boolean)?;
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
@@ -171,12 +172,12 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 
     /// Check that the plan has the correct data type
-    fn check_data_type(&self, data_type: ColumnType) -> ConversionResult<()> {
-        if self.data_type() == data_type {
+    fn check_data_type_kind(&self, data_type: ColumnTypeKind) -> ConversionResult<()> {
+        if self.data_type_kind() == data_type {
             Ok(())
         } else {
-            Err(ConversionError::InvalidDataType {
-                actual: self.data_type(),
+            Err(ConversionError::InvalidDataTypeKind {
+                actual: self.data_type_kind(),
                 expected: data_type,
             })
         }
@@ -213,7 +214,6 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
             | DynProofExpr::Inequality(_) => ColumnType::Boolean(ColumnNullability::default()),
         }
     }
-
     fn result_evaluate<'a>(
         &self,
         table_length: usize,

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -2,11 +2,13 @@ use super::{
     AddSubtractExpr, AggregateExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
     MultiplyExpr, NotExpr, OrExpr, ProofExpr,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor, LiteralValue,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -2,6 +2,7 @@ use super::{
     AddSubtractExpr, AggregateExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
     MultiplyExpr, NotExpr, OrExpr, ProofExpr,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -19,7 +20,6 @@ use bumpalo::Bump;
 use core::fmt::Debug;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -208,7 +208,9 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
             | DynProofExpr::Or(_)
             | DynProofExpr::Not(_)
             | DynProofExpr::Equals(_)
-            | DynProofExpr::Inequality(_) => ColumnType::Boolean(ColumnTypeAssociatedData::default()),
+            | DynProofExpr::Inequality(_) => {
+                ColumnType::Boolean(ColumnTypeAssociatedData::default())
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -2,13 +2,12 @@ use super::{
     AddSubtractExpr, AggregateExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr,
     MultiplyExpr, NotExpr, OrExpr, ProofExpr,
 };
-use crate::base::database::ColumnTypeKind;
 use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            LiteralValue,
+            Column, ColumnNullability, ColumnRef, ColumnType, ColumnTypeKind, CommitmentAccessor,
+            DataAccessor, LiteralValue,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,9 +1,11 @@
 use super::{scale_and_add_subtract_eval, scale_and_subtract, DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,4 +1,5 @@
 use super::{scale_and_add_subtract_eval, scale_and_subtract, DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -13,7 +14,6 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable AST expression for an equals expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -56,7 +56,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
             .expect("Failed to scale and subtract");
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            result_evaluate_equals_zero(table_length, alloc, res)
+            result_evaluate_equals_zero(table_length, alloc, res),
         )
     }
 
@@ -75,7 +75,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
             .expect("Failed to scale and subtract");
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            prover_evaluate_equals_zero(builder, alloc, res)
+            prover_evaluate_equals_zero(builder, alloc, res),
         )
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -40,7 +39,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        ColumnType::Boolean(ColumnNullability::NotNullable)
     }
 
     #[tracing::instrument(name = "EqualsExpr::result_evaluate", level = "debug", skip_all)]
@@ -57,7 +56,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
         let res = scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, true)
             .expect("Failed to scale and subtract");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             result_evaluate_equals_zero(table_length, alloc, res),
         )
     }
@@ -76,7 +75,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
         let res = scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, true)
             .expect("Failed to scale and subtract");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             prover_evaluate_equals_zero(builder, alloc, res),
         )
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -18,7 +19,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_an_equality_query_with_no_rows() {
@@ -414,6 +414,9 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = equals_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true, false]);
+    let expected_res = Column::Boolean(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[true, false, true, false],
+    );
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -18,6 +18,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_an_equality_query_with_no_rows() {
@@ -413,6 +414,6 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = equals_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false, true, false]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -1,8 +1,10 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTable, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTable,
+            OwnedTableTestAccessor,
+        },
         scalar::{Curve25519Scalar, Scalar},
     },
     sql::{

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -2,8 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTable,
-            OwnedTableTestAccessor,
+            owned_table_utility::*, Column, ColumnNullability, OwnedTable, OwnedTableTestAccessor,
         },
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -416,9 +415,6 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = equals_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[true, false, true, false],
-    );
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[true, false, true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -4,11 +4,13 @@ use super::{
     scale_and_add_subtract_eval, scale_and_subtract, verifier_evaluate_equals_zero,
     verifier_evaluate_or, verifier_evaluate_sign, DynProofExpr, ProofExpr,
 };
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -4,6 +4,7 @@ use super::{
     scale_and_add_subtract_eval, scale_and_subtract, verifier_evaluate_equals_zero,
     verifier_evaluate_or, verifier_evaluate_sign, DynProofExpr, ProofExpr,
 };
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -16,7 +17,6 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable AST expression for an inequality expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
         // (diff == 0) || (sign(diff) == -1)
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            result_evaluate_or(table_length, alloc, equals_zero, sign)
+            result_evaluate_or(table_length, alloc, equals_zero, sign),
         )
     }
 
@@ -121,7 +121,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
         // (diff == 0) || (sign(diff) == -1)
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            prover_evaluate_or(builder, alloc, equals_zero, sign)
+            prover_evaluate_or(builder, alloc, equals_zero, sign),
         )
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -8,8 +8,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -54,7 +53,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        ColumnType::Boolean(ColumnNullability::NotNullable)
     }
 
     #[tracing::instrument(name = "InequalityExpr::result_evaluate", level = "debug", skip_all)]
@@ -84,7 +83,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
 
         // (diff == 0) || (sign(diff) == -1)
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             result_evaluate_or(table_length, alloc, equals_zero, sign),
         )
     }
@@ -122,7 +121,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
 
         // (diff == 0) || (sign(diff) == -1)
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             prover_evaluate_or(builder, alloc, equals_zero, sign),
         )
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -16,6 +16,7 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable AST expression for an inequality expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -51,7 +52,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean
+        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
     }
 
     #[tracing::instrument(name = "InequalityExpr::result_evaluate", level = "debug", skip_all)]
@@ -80,7 +81,10 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
         let sign = result_evaluate_sign(table_length, alloc, diff);
 
         // (diff == 0) || (sign(diff) == -1)
-        Column::Boolean(result_evaluate_or(table_length, alloc, equals_zero, sign))
+        Column::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            result_evaluate_or(table_length, alloc, equals_zero, sign)
+        )
     }
 
     #[tracing::instrument(name = "InequalityExpr::prover_evaluate", level = "debug", skip_all)]
@@ -115,7 +119,10 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
         );
 
         // (diff == 0) || (sign(diff) == -1)
-        Column::Boolean(prover_evaluate_or(builder, alloc, equals_zero, sign))
+        Column::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            prover_evaluate_or(builder, alloc, equals_zero, sign)
+        )
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -24,6 +24,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
@@ -571,7 +572,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lte_expr = lte(lhs_expr, rhs_expr);
     let alloc = Bump::new();
     let res = lte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false, true]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true]);
     assert_eq!(res, expected_res);
 }
 
@@ -586,6 +587,6 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let gte_expr = gte(col_expr, lit_expr);
     let alloc = Bump::new();
     let res = gte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, true]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, LiteralValue, OwnedTable,
+            owned_table_utility::*, Column, ColumnNullability, LiteralValue, OwnedTable,
             OwnedTableTestAccessor, TestAccessor,
         },
         math::decimal::scale_scalar,
@@ -571,8 +571,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lte_expr = lte(lhs_expr, rhs_expr);
     let alloc = Bump::new();
     let res = lte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res =
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true]);
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[true, false, true]);
     assert_eq!(res, expected_res);
 }
 
@@ -587,7 +586,6 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let gte_expr = gte(col_expr, lit_expr);
     let alloc = Bump::new();
     let res = gte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res =
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true]);
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -24,7 +25,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
@@ -572,7 +572,8 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lte_expr = lte(lhs_expr, rhs_expr);
     let alloc = Bump::new();
     let res = lte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true]);
+    let expected_res =
+        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false, true]);
     assert_eq!(res, expected_res);
 }
 
@@ -587,6 +588,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let gte_expr = gte(col_expr, lit_expr);
     let alloc = Bump::new();
     let res = gte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true]);
+    let expected_res =
+        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -1,10 +1,9 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, LiteralValue, OwnedTable, OwnedTableTestAccessor,
-            TestAccessor,
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, LiteralValue, OwnedTable,
+            OwnedTableTestAccessor, TestAccessor,
         },
         math::decimal::scale_scalar,
         scalar::{Curve25519Scalar, Scalar},

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -17,6 +17,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 fn test_random_tables_with_given_offset(offset: usize) {
     let dist = Uniform::new(-3, 4);
@@ -125,6 +126,6 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let literal_expr: DynProofExpr<RistrettoPoint> = const_bool(true);
     let alloc = Bump::new();
     let res = literal_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, true, true, true]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -17,7 +18,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 fn test_random_tables_with_given_offset(offset: usize) {
     let dist = Uniform::new(-3, 4);
@@ -126,6 +126,9 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let literal_expr: DynProofExpr<RistrettoPoint> = const_bool(true);
     let alloc = Bump::new();
     let res = literal_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, true, true, true]);
+    let expected_res = Column::Boolean(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[true, true, true, true],
+    );
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -1,9 +1,10 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -2,9 +2,7 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-        },
+        database::{owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor},
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -127,9 +125,6 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let literal_expr: DynProofExpr<RistrettoPoint> = const_bool(true);
     let alloc = Bump::new();
     let res = literal_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[true, true, true, true],
-    );
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[true, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -18,6 +18,7 @@ use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -59,7 +60,7 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
         let scalars = multiply_columns(&lhs_column, &rhs_column, alloc);
-        Column::Scalar(scalars)
+        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, scalars)
     }
 
     #[tracing::instrument(
@@ -91,7 +92,7 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
                 ),
             ],
         );
-        Column::Scalar(lhs_times_rhs)
+        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, lhs_times_rhs)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -18,7 +19,6 @@ use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            try_multiply_column_types, Column, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            try_multiply_column_types, Column, ColumnNullability, ColumnRef, ColumnType,
             CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
@@ -59,7 +59,7 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
         let rhs_column: Column<'a, C::Scalar> =
             self.rhs.result_evaluate(table_length, alloc, accessor);
         let scalars = multiply_columns(&lhs_column, &rhs_column, alloc);
-        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, scalars)
+        Column::Scalar(ColumnNullability::NotNullable, scalars)
     }
 
     #[tracing::instrument(
@@ -91,7 +91,7 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
                 ),
             ],
         );
-        Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, lhs_times_rhs)
+        Column::Scalar(ColumnNullability::NotNullable, lhs_times_rhs)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,11 +1,10 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
         database::{
-            try_multiply_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
+            try_multiply_column_types, Column, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -1,9 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-        },
+        database::{owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor},
         scalar::Curve25519Scalar,
     },
     sql::{
@@ -353,6 +351,6 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &expected_res_scalar);
+    let expected_res = Column::Scalar(ColumnNullability::NotNullable, &expected_res_scalar);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -19,6 +19,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 // select a * 2 as a, c, b * 4.5 as b, d * 3  + 4.7 as d, e from sxt.t where d * 3.9 = 8.19
 #[test]
@@ -351,6 +352,6 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(&expected_res_scalar);
+    let expected_res = Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, &expected_res_scalar);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -19,7 +20,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 // select a * 2 as a, c, b * 4.5 as b, d * 3  + 4.7 as d, e from sxt.t where d * 3.9 = 8.19
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -1,8 +1,9 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+        },
         scalar::Curve25519Scalar,
     },
     sql::{

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -11,7 +12,6 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable logical NOT expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -45,7 +45,10 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
         let expr_column: Column<'a, C::Scalar> =
             self.expr.result_evaluate(table_length, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
+        Column::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]),
+        )
     }
 
     #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
@@ -60,7 +63,7 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i])
+            alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]),
         )
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -34,7 +33,7 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        ColumnType::Boolean(ColumnNullability::NotNullable)
     }
 
     #[tracing::instrument(name = "NotExpr::result_evaluate", level = "debug", skip_all)]
@@ -48,7 +47,7 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
             self.expr.result_evaluate(table_length, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]),
         )
     }
@@ -64,7 +63,7 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
             self.expr.prover_evaluate(builder, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]),
         )
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,9 +1,11 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -17,7 +18,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -1,8 +1,10 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+            TestAccessor,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -2,8 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-            TestAccessor,
+            owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor, TestAccessor,
         },
     },
     sql::{
@@ -124,6 +123,6 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
         not(equal(column(t, "b", &accessor), const_int128(1)));
     let alloc = Bump::new();
     let res = not_expr.result_evaluate(2, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false]);
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -17,6 +17,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
@@ -121,6 +122,6 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
         not(equal(column(t, "b", &accessor), const_int128(1)));
     let alloc = Bump::new();
     let res = not_expr.result_evaluate(2, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,9 +1,11 @@
 use super::{DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnRef, ColumnType, ColumnTypeAssociatedData, CommitmentAccessor,
-            DataAccessor,
+            Column, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -39,7 +38,7 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        ColumnType::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE)
+        ColumnType::Boolean(ColumnNullability::NotNullable)
     }
 
     #[tracing::instrument(name = "OrExpr::result_evaluate", level = "debug", skip_all)]
@@ -56,7 +55,7 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             result_evaluate_or(table_length, alloc, lhs, rhs),
         )
     }
@@ -73,7 +72,7 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(
-            ColumnTypeAssociatedData::NOT_NULLABLE,
+            ColumnNullability::NotNullable,
             prover_evaluate_or(builder, alloc, lhs, rhs),
         )
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,4 +1,5 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -12,7 +13,6 @@ use crate::{
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable logical OR expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -55,7 +55,7 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(
             ColumnTypeAssociatedData::NOT_NULLABLE,
-            result_evaluate_or(table_length, alloc, lhs, rhs)
+            result_evaluate_or(table_length, alloc, lhs, rhs),
         )
     }
 
@@ -70,7 +70,10 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
         let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, prover_evaluate_or(builder, alloc, lhs, rhs))
+        Column::Boolean(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            prover_evaluate_or(builder, alloc, lhs, rhs),
+        )
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -17,6 +17,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_simple_or_query() {
@@ -185,6 +186,6 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, true, true]);
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -1,8 +1,10 @@
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+            TestAccessor,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -17,7 +18,6 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_prove_a_simple_or_query() {
@@ -186,6 +186,9 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[false, true, true, true]);
+    let expected_res = Column::Boolean(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[false, true, true, true],
+    );
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -2,8 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-            TestAccessor,
+            owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor, TestAccessor,
         },
     },
     sql::{
@@ -188,9 +187,6 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
-        &[false, true, true, true],
-    );
+    let expected_res = Column::Boolean(ColumnNullability::NotNullable, &[false, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnTypeKind;
 use crate::{
     base::{
         commitment::Commitment,
@@ -17,6 +18,10 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
 
     /// Get the data type of the expression
     fn data_type(&self) -> ColumnType;
+    /// Get the data type of the expression
+    fn data_type_kind(&self) -> ColumnTypeKind {
+        self.data_type().get_kind()
+    }
 
     /// This returns the result of evaluating the expression on the given table, and returns
     /// a column of values. This result slice is guarenteed to have length `table_length`.

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,8 +1,9 @@
-use crate::base::database::ColumnTypeKind;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnTypeKind, CommitmentAccessor, DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,11 +1,11 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     commitment::InnerProductProof,
     database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
 };
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluate() {
@@ -38,9 +38,12 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
     );
     let alloc = Bump::new();
     let res = bool_expr.result_evaluate(17, &alloc, &accessor);
-    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[
-        false, true, false, true, false, true, false, true, false, true, false, true, false, true,
-        false, false, false,
-    ]);
+    let expected_res = Column::Boolean(
+        ColumnTypeAssociatedData::NOT_NULLABLE,
+        &[
+            false, true, false, true, false, true, false, true, false, true, false, true, false,
+            true, false, false, false,
+        ],
+    );
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,8 +1,10 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{
     commitment::InnerProductProof,
-    database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+    database::{
+        owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
+        TestAccessor,
+    },
 };
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -2,8 +2,7 @@ use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
     commitment::InnerProductProof,
     database::{
-        owned_table_utility::*, Column, ColumnTypeAssociatedData, OwnedTableTestAccessor,
-        TestAccessor,
+        owned_table_utility::*, Column, ColumnNullability, OwnedTableTestAccessor, TestAccessor,
     },
 };
 use bumpalo::Bump;
@@ -41,7 +40,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
     let alloc = Bump::new();
     let res = bool_expr.result_evaluate(17, &alloc, &accessor);
     let expected_res = Column::Boolean(
-        ColumnTypeAssociatedData::NOT_NULLABLE,
+        ColumnNullability::NotNullable,
         &[
             false, true, false, true, false, true, false, true, false, true, false, true, false,
             true, false, false, false,

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -5,6 +5,7 @@ use crate::base::{
 };
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluate() {
@@ -37,7 +38,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
     );
     let alloc = Bump::new();
     let res = bool_expr.result_evaluate(17, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[
+    let expected_res = Column::Boolean(ColumnTypeAssociatedData::NOT_NULLABLE, &[
         false, true, false, true, false, true, false, true, false, true, false, true, false, true,
         false, false, false,
     ]);

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -21,6 +21,7 @@ use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -33,7 +34,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
                 ))),
                 "a",
             ),
@@ -41,7 +42,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     b,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
                 ))),
                 "b",
             ),
@@ -51,7 +52,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
             DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                 table_ref,
                 Identifier::try_new("c").unwrap(),
-                ColumnType::BigInt,
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
             ))),
             DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(123))),
         )
@@ -62,14 +63,15 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     assert_eq!(
         column_fields,
         vec![
-            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
-            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt)
+            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
+            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
         ]
     );
 }
 
 #[test]
 fn we_can_correctly_fetch_all_the_referenced_columns() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
@@ -79,7 +81,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "a",
             ),
@@ -87,7 +89,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     f,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "f",
             ),
@@ -99,7 +101,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                     DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                         table_ref,
                         Identifier::try_new("f").unwrap(),
-                        ColumnType::BigInt,
+                        ColumnType::BigInt(meta),
                     ))),
                     DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(45))),
                 )
@@ -108,7 +110,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                     DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                         table_ref,
                         Identifier::try_new("c").unwrap(),
-                        ColumnType::BigInt,
+                        ColumnType::BigInt(meta),
                     ))),
                     DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(-2))),
                 )
@@ -118,7 +120,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     Identifier::try_new("b").unwrap(),
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(3))),
             )
@@ -134,22 +136,22 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             ),
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("f").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             ),
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("c").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             ),
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("b").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             )
         ])
     );
@@ -174,6 +176,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result_evaluate() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let data = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
@@ -197,12 +200,12 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("c".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "e".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(75).unwrap(), 0),
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
@@ -221,6 +224,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),
@@ -244,12 +248,12 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("c".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "e".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(1).unwrap(), 0),
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
@@ -297,6 +301,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
 
 #[test]
 fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),
@@ -320,12 +325,12 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("c".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "e".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(1).unwrap(), 0),
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -1,4 +1,5 @@
 use super::{test_utility::*, FilterExec};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{
@@ -21,7 +22,6 @@ use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -63,8 +63,14 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     assert_eq!(
         column_fields,
         vec![
-            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)),
-            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE))
+            ColumnField::new(
+                "a".parse().unwrap(),
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            ),
+            ColumnField::new(
+                "b".parse().unwrap(),
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+            )
         ]
     );
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -1,10 +1,10 @@
 use super::{test_utility::*, FilterExec};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, LiteralValue,
-            OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
+            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType,
+            ColumnTypeAssociatedData, LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef,
+            TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -2,9 +2,8 @@ use super::{test_utility::*, FilterExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType,
-            ColumnTypeAssociatedData, LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef,
-            TestAccessor,
+            owned_table_utility::*, Column, ColumnField, ColumnNullability, ColumnRef, ColumnType,
+            LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
@@ -34,7 +33,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
-                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                    ColumnType::BigInt(ColumnNullability::NotNullable),
                 ))),
                 "a",
             ),
@@ -42,7 +41,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     b,
-                    ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                    ColumnType::BigInt(ColumnNullability::NotNullable),
                 ))),
                 "b",
             ),
@@ -52,7 +51,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
             DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                 table_ref,
                 Identifier::try_new("c").unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                ColumnType::BigInt(ColumnNullability::NotNullable),
             ))),
             DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(123))),
         )
@@ -65,11 +64,11 @@ fn we_can_correctly_fetch_the_query_result_schema() {
         vec![
             ColumnField::new(
                 "a".parse().unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ColumnType::BigInt(ColumnNullability::NotNullable)
             ),
             ColumnField::new(
                 "b".parse().unwrap(),
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE)
+                ColumnType::BigInt(ColumnNullability::NotNullable)
             )
         ]
     );
@@ -77,7 +76,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
 
 #[test]
 fn we_can_correctly_fetch_all_the_referenced_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
@@ -182,7 +181,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result_evaluate() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let data = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
@@ -230,7 +229,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),
@@ -307,7 +306,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
 
 #[test]
 fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -123,12 +123,12 @@ fn tamper_column<'a>(
     mut columns: Vec<Column<'a, Curve25519Scalar>>,
 ) -> Vec<Column<'a, Curve25519Scalar>> {
     for column in &mut columns {
-        if let Column::Scalar(tampered_column) = column {
+        if let Column::Scalar(meta, tampered_column) = column {
             if !tampered_column.is_empty() {
                 let tampered_column = alloc.alloc_slice_copy(tampered_column);
                 // The following could be changed for different types of tests, but for the simplest one, we will simply increase the first element by 1.
                 tampered_column[0] += Curve25519Scalar::one();
-                *column = Column::Scalar(tampered_column);
+                *column = Column::Scalar(meta.clone(), tampered_column);
                 break;
             }
         }

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -2,9 +2,11 @@ use super::{fold_columns, fold_vals};
 use crate::base::{database::Column, math::decimal::Precision, scalar::Curve25519Scalar};
 use bumpalo::Bump;
 use num_traits::Zero;
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_fold_columns_with_scalars() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let expected = vec![
         Curve25519Scalar::from(77 + 2061 * 33)
             + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
@@ -22,10 +24,10 @@ fn we_can_fold_columns_with_scalars() {
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [2.into(), 3.into(), 5.into(), 7.into(), 1.into()];
     let mut columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[6, 7, 8, 9, 0]),
-        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
-        Column::Scalar(&scalars),
+        Column::BigInt(meta, &[1, 2, 3, 4, 5]),
+        Column::Int128(meta, &[6, 7, 8, 9, 0]),
+        Column::VarChar(meta, (&["1", "2", "3", "4", "5"], &str_scalars)),
+        Column::Scalar(meta, &scalars),
     ];
 
     let alloc = Bump::new();
@@ -35,7 +37,7 @@ fn we_can_fold_columns_with_scalars() {
     assert_eq!(result, expected);
 
     columns.pop();
-    columns.push(Column::Decimal75(Precision::new(75).unwrap(), -1, &scalars));
+    columns.push(Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &scalars));
 
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(5, 77.into());
@@ -46,6 +48,7 @@ fn we_can_fold_columns_with_scalars() {
 
 #[test]
 fn we_can_fold_columns_with_that_get_padded() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let expected = vec![
         Curve25519Scalar::from(77 + 2061 * 33)
             + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
@@ -66,10 +69,10 @@ fn we_can_fold_columns_with_that_get_padded() {
     let str_scalars: [Curve25519Scalar; 3] = ["1".into(), "2".into(), "3".into()];
     let scalars = [2.into(), 3.into()];
     let mut columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[6, 7, 8, 9]),
-        Column::VarChar((&["1", "2", "3"], &str_scalars)),
-        Column::Scalar(&scalars),
+        Column::BigInt(meta, &[1, 2, 3, 4, 5]),
+        Column::Int128(meta, &[6, 7, 8, 9]),
+        Column::VarChar(meta, (&["1", "2", "3"], &str_scalars)),
+        Column::Scalar(meta, &scalars),
     ];
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(11, 77.into());
@@ -78,7 +81,7 @@ fn we_can_fold_columns_with_that_get_padded() {
     assert_eq!(result, expected);
 
     columns.pop();
-    columns.push(Column::Decimal75(Precision::new(75).unwrap(), -1, &scalars));
+    columns.push(Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &scalars));
 
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(11, 77.into());
@@ -89,12 +92,13 @@ fn we_can_fold_columns_with_that_get_padded() {
 
 #[test]
 fn we_can_fold_empty_columns() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let columns = vec![
-        Column::BigInt::<Curve25519Scalar>(&[]),
-        Column::Int128(&[]),
-        Column::VarChar((&[], &[])),
-        Column::Scalar(&[]),
-        Column::Decimal75(Precision::new(75).unwrap(), -1, &[]),
+        Column::BigInt::<Curve25519Scalar>(meta, &[]),
+        Column::Int128(meta, &[]),
+        Column::VarChar(meta, (&[], &[])),
+        Column::Scalar(meta, &[]),
+        Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &[]),
     ];
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(0, 77.into());

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,6 +1,6 @@
 use super::{fold_columns, fold_vals};
 use crate::base::{
-    database::{Column, ColumnTypeAssociatedData},
+    database::{Column, ColumnNullability},
     math::decimal::Precision,
     scalar::Curve25519Scalar,
 };
@@ -9,7 +9,7 @@ use num_traits::Zero;
 
 #[test]
 fn we_can_fold_columns_with_scalars() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let expected = vec![
         Curve25519Scalar::from(77 + 2061 * 33)
             + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
@@ -56,7 +56,7 @@ fn we_can_fold_columns_with_scalars() {
 
 #[test]
 fn we_can_fold_columns_with_that_get_padded() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let expected = vec![
         Curve25519Scalar::from(77 + 2061 * 33)
             + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
@@ -105,7 +105,7 @@ fn we_can_fold_columns_with_that_get_padded() {
 
 #[test]
 fn we_can_fold_empty_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let columns = vec![
         Column::BigInt::<Curve25519Scalar>(meta, &[]),
         Column::Int128(meta, &[]),

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,6 +1,9 @@
 use super::{fold_columns, fold_vals};
-use crate::base::database::ColumnTypeAssociatedData;
-use crate::base::{database::Column, math::decimal::Precision, scalar::Curve25519Scalar};
+use crate::base::{
+    database::{Column, ColumnTypeAssociatedData},
+    math::decimal::Precision,
+    scalar::Curve25519Scalar,
+};
 use bumpalo::Bump;
 use num_traits::Zero;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -1,8 +1,8 @@
 use super::{fold_columns, fold_vals};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::base::{database::Column, math::decimal::Precision, scalar::Curve25519Scalar};
 use bumpalo::Bump;
 use num_traits::Zero;
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_fold_columns_with_scalars() {
@@ -37,7 +37,12 @@ fn we_can_fold_columns_with_scalars() {
     assert_eq!(result, expected);
 
     columns.pop();
-    columns.push(Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &scalars));
+    columns.push(Column::Decimal75(
+        meta,
+        Precision::new(75).unwrap(),
+        -1,
+        &scalars,
+    ));
 
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(5, 77.into());
@@ -81,7 +86,12 @@ fn we_can_fold_columns_with_that_get_padded() {
     assert_eq!(result, expected);
 
     columns.pop();
-    columns.push(Column::Decimal75(meta, Precision::new(75).unwrap(), -1, &scalars));
+    columns.push(Column::Decimal75(
+        meta,
+        Precision::new(75).unwrap(),
+        -1,
+        &scalars,
+    ));
 
     let alloc = Bump::new();
     let result = alloc.alloc_slice_fill_copy(11, 77.into());

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -1,5 +1,4 @@
 use super::{fold_columns, fold_vals};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         commitment::Commitment,
@@ -7,8 +6,8 @@ use crate::{
             group_by_util::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
             },
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable,
+            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
+            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
         },
         map::IndexSet,
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -6,8 +6,8 @@ use crate::{
             group_by_util::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
             },
-            Column, ColumnField, ColumnRef, ColumnType, ColumnTypeAssociatedData,
-            CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+            Column, ColumnField, ColumnNullability, ColumnRef, ColumnType, CommitmentAccessor,
+            DataAccessor, MetadataAccessor, OwnedTable,
         },
         map::IndexSet,
         proof::ProofError,
@@ -183,7 +183,7 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
             }))
             .chain(iter::once(ColumnField::new(
                 self.count_alias,
-                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
+                ColumnType::BigInt(ColumnNullability::NotNullable),
             )))
             .collect()
     }
@@ -246,12 +246,12 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
             .expect("columns should be aggregatable");
         let sum_result_columns_iter = sum_result_columns
             .iter()
-            .map(|col| Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, col));
+            .map(|col| Column::Scalar(ColumnNullability::NotNullable, col));
         group_by_result_columns
             .into_iter()
             .chain(sum_result_columns_iter)
             .chain(iter::once(Column::BigInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 count_column,
             )))
             .collect::<Vec<_>>()
@@ -302,13 +302,13 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
         // 4. Tally results
         let sum_result_columns_iter = sum_result_columns
             .iter()
-            .map(|col| Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, col));
+            .map(|col| Column::Scalar(ColumnNullability::NotNullable, col));
         let res = group_by_result_columns
             .clone()
             .into_iter()
             .chain(sum_result_columns_iter)
             .chain(core::iter::once(Column::BigInt(
-                ColumnTypeAssociatedData::NOT_NULLABLE,
+                ColumnNullability::NotNullable,
                 count_column,
             )))
             .collect::<Vec<_>>();

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -28,6 +28,7 @@ use core::{iter, iter::repeat_with};
 use num_traits::One;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
+use crate::base::database::ColumnTypeAssociatedData;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -183,7 +184,7 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
             }))
             .chain(iter::once(ColumnField::new(
                 self.count_alias,
-                ColumnType::BigInt,
+                ColumnType::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE),
             )))
             .collect()
     }
@@ -244,11 +245,14 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
             ..
         } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
             .expect("columns should be aggregatable");
-        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
+        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(
+            ColumnTypeAssociatedData::NOT_NULLABLE,
+            col
+        ));
         group_by_result_columns
             .into_iter()
             .chain(sum_result_columns_iter)
-            .chain(iter::once(Column::BigInt(count_column)))
+            .chain(iter::once(Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, count_column)))
             .collect::<Vec<_>>()
     }
 
@@ -295,12 +299,12 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
         let beta = builder.consume_post_result_challenge();
 
         // 4. Tally results
-        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
+        let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(ColumnTypeAssociatedData::NOT_NULLABLE, col));
         let res = group_by_result_columns
             .clone()
             .into_iter()
             .chain(sum_result_columns_iter)
-            .chain(core::iter::once(Column::BigInt(count_column)))
+            .chain(core::iter::once(Column::BigInt(ColumnTypeAssociatedData::NOT_NULLABLE, count_column)))
             .collect::<Vec<_>>();
         // 5. Produce MLEs
         res.iter().copied().for_each(|column| {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -2,8 +2,8 @@ use super::{test_utility::*, DynProofPlan, ProjectionExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType,
-            ColumnTypeAssociatedData, OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
+            owned_table_utility::*, Column, ColumnField, ColumnNullability, ColumnRef, ColumnType,
+            OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
@@ -24,7 +24,7 @@ use proof_of_sql_parser::{Identifier, ResourceId};
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let b = Identifier::try_new("b").unwrap();
@@ -61,7 +61,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
 
 #[test]
 fn we_can_correctly_fetch_all_the_referenced_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
@@ -154,7 +154,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_result_evaluate() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let data = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
@@ -224,7 +224,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
 
 #[test]
 fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let meta = ColumnNullability::NotNullable;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -1,10 +1,9 @@
 use super::{test_utility::*, DynProofPlan, ProjectionExec};
-use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, OwnedTable,
-            OwnedTableTestAccessor, TableRef, TestAccessor,
+            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType,
+            ColumnTypeAssociatedData, OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -21,9 +21,11 @@ use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
+use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let b = Identifier::try_new("b").unwrap();
@@ -33,7 +35,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "a",
             ),
@@ -41,7 +43,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     b,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "b",
             ),
@@ -52,15 +54,15 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     assert_eq!(
         column_fields,
         vec![
-            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
-            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
+            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt(meta)),
+            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
         ]
     );
 }
 
 #[test]
 fn we_can_correctly_fetch_all_the_referenced_columns() {
-    let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE; let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
     let provable_ast = ProjectionExec::<RistrettoPoint>::new(
@@ -69,7 +71,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "a",
             ),
@@ -77,7 +79,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     f,
-                    ColumnType::BigInt,
+                    ColumnType::BigInt(meta),
                 ))),
                 "f",
             ),
@@ -93,12 +95,12 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             ),
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("f").unwrap(),
-                ColumnType::BigInt
+                ColumnType::BigInt(meta)
             ),
         ])
     );
@@ -152,6 +154,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
 
 #[test]
 fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_result_evaluate() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let data = owned_table([
         bigint("a", [0; 0]),
         bigint("b", [0; 0]),
@@ -170,12 +173,12 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("c".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "e".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(75).unwrap(), 0),
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
@@ -221,6 +224,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
 
 #[test]
 fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate() {
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
     let data = owned_table([
         bigint("a", [1, 4, 5, 2, 5]),
         bigint("b", [1, 2, 3, 4, 5]),
@@ -249,12 +253,12 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
-        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
-        ColumnField::new("prod".parse().unwrap(), ColumnType::Int128),
-        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar),
+        ColumnField::new("b".parse().unwrap(), ColumnType::BigInt(meta)),
+        ColumnField::new("prod".parse().unwrap(), ColumnType::Int128(meta)),
+        ColumnField::new("d".parse().unwrap(), ColumnType::VarChar(meta)),
         ColumnField::new(
             "e".parse().unwrap(),
-            ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
+            ColumnType::Decimal75(meta, Precision::new(1).unwrap(), 0),
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -1,4 +1,5 @@
 use super::{test_utility::*, DynProofPlan, ProjectionExec};
+use crate::base::database::ColumnTypeAssociatedData;
 use crate::{
     base::{
         database::{
@@ -21,7 +22,6 @@ use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
-use crate::base::database::ColumnTypeAssociatedData;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -62,7 +62,8 @@ fn we_can_correctly_fetch_the_query_result_schema() {
 
 #[test]
 fn we_can_correctly_fetch_all_the_referenced_columns() {
-    let meta = ColumnTypeAssociatedData::NOT_NULLABLE; let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
+    let meta = ColumnTypeAssociatedData::NOT_NULLABLE;
+    let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
     let provable_ast = ProjectionExec::<RistrettoPoint>::new(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
